### PR TITLE
Create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# These owners are the default owners for everything in
+# the repo. Unless a later match takes precedence,
+* @kousuke-nakano @addman2 @michele-casula
+
+# @kousuke-nakano owns any files in the build/ directory at 
+# the root of the repository and any of its subdirectories.
+# /doc/ @kousuke-nakano


### PR DESCRIPTION
Created CODEOWNERS file

- Created CODEOWNERS file.
- Reviews from two code owners are needed for merging a branch to the `main` branch (see the protection rule).
- Review from one code owner is needed for merging a branch to the `devel` branch. A code owner can, in principle, bypass the review (see the protection rule).  

#2 