### PR TITLE
Fix compile time warnings

### DIFF
--- a/src/m_common/fft_stick.c
+++ b/src/m_common/fft_stick.c
@@ -94,10 +94,9 @@ int F77_FUNC_(destroy_plan_3d, DESTROY_PLAN_3D)(fftwnd_plan *p)
 int F77_FUNC_(fft_x_stick, FFT_X_STICK)(fftw_plan *p, FFTW_COMPLEX *a, int *nx, int *ny, int *nz, int *ldx, int *ldy)
 {
 
-   int i, j, ind;
+   int i;
    int xstride, bigstride;
    int xhowmany, xidist;
-   double *ptr;
 
    /* trasform  along x and y */
    bigstride = (*ldx) * (*ldy);
@@ -105,8 +104,6 @@ int F77_FUNC_(fft_x_stick, FFT_X_STICK)(fftw_plan *p, FFTW_COMPLEX *a, int *nx, 
    xhowmany = (*ny);
    xstride = 1;
    xidist = (*ldx);
-
-   /* ptr = (double *)a; */
 
    for (i = 0; i < *nz; i++)
    {

--- a/src/m_common/zsktrs_qp.f90
+++ b/src/m_common/zsktrs_qp.f90
@@ -17,7 +17,11 @@ subroutine zsktrs(uplo, n, nhrs, a, b, ldb, x, info)
     implicit none
     integer n, nhrs, ldb, info, i, j
     complex*16 a(*), b(ldb, *), x(*)
+#ifdef __PORT
+    complex*16 aq, a2q, xo
+#else
     complex*32 aq, a2q, xo
+#endif
     character uplo
     if (uplo .eq. 'l' .or. uplo .eq. 'L') then
         a(1:n - 1) = -a(1:n - 1)


### PR DESCRIPTION
Fixing compile time warnings. There is still one in C code, where macros are complaining that diferent types are passed. But this code is OK. I don't know how to suppress this warning except for compile flag.

Fixing #17 