### PR TITLE
Fix bad preprocessor macros for non-cusolver GPU build

### DIFF
--- a/src/a_module_tests/test_dgetrf.f90
+++ b/src/a_module_tests/test_dgetrf.f90
@@ -15,7 +15,7 @@
 
 program test_dgetrf
 
-#if defined(_OFFLOAD) && defined(_CUBLAS)
+#if defined(_OFFLOAD) && defined(_CUSOLVER)
     use allio, only: handle, dev_dgetrf_workspace, dev_Info
 #endif
 
@@ -27,7 +27,7 @@ program test_dgetrf
     real*8 :: one = 1.d0, zero = 0.d0
     integer :: s, gen, info, ii, jj, kk
 
-#if defined(_OFFLOAD) && defined(_CUBLAS)
+#if defined(_OFFLOAD) && defined(_CUSOLVER)
     integer :: lworkspace, stat
 #endif
 
@@ -36,7 +36,7 @@ program test_dgetrf
 
     read (*, *) s, gen
 
-#if defined(_OFFLOAD) && defined(_CUBLAS)
+#if defined(_OFFLOAD) && defined(_CUSOLVER)
     lworkspace = 1
 #ifdef RISC
     call cusolver_handle_init_(handle)
@@ -85,14 +85,14 @@ program test_dgetrf
 
     C = A
 
-#if defined(_OFFLOAD) && defined(_CUBLAS)
+#if defined(_OFFLOAD) && defined(_CUSOLVER)
 !$omp target data map(tofrom:C,ipiv)
 #endif
     call dgetrf_(s, s&
                 &, C, s&
                 &, ipiv&
                 &, info)
-#if defined(_OFFLOAD) && defined(_CUBLAS)
+#if defined(_OFFLOAD) && defined(_CUSOLVER)
 !$omp end target data
 #endif
 
@@ -143,7 +143,7 @@ program test_dgetrf
         print *, "OK"
     end if
 
-#if defined(_OFFLOAD) && defined(_CUBLAS)
+#if defined(_OFFLOAD) && defined(_CUSOLVER)
 !$omp end target data
 #ifdef RISC
     call cusolver_handle_destroy_(handle)
@@ -154,7 +154,7 @@ program test_dgetrf
 
     deallocate (A, ipiv, temp, upper, lower, C)
 
-#if defined(_OFFLOAD) && defined(_CUBLAS)
+#if defined(_OFFLOAD) && defined(_CUSOLVER)
     deallocate (dev_dgetrf_workspace)
 #endif
 

--- a/src/a_module_tests/test_zgetrf.f90
+++ b/src/a_module_tests/test_zgetrf.f90
@@ -15,7 +15,7 @@
 
 program test_zgetrf
 
-#if defined(_OFFLOAD) && defined(_CUBLAS)
+#if defined(_OFFLOAD) && defined(_CUSOLVER)
     use allio, only: handle, dev_zgetrf_workspace, dev_Info
 #endif
 
@@ -28,7 +28,7 @@ program test_zgetrf
     real*8 :: one = 1.d0, zero = 0.d0
     integer :: s, gen, info, ii, jj, kk
 
-#if defined(_OFFLOAD) && defined(_CUBLAS)
+#if defined(_OFFLOAD) && defined(_CUSOLVER)
     integer :: lworkspace, stat
 #endif
 
@@ -37,7 +37,7 @@ program test_zgetrf
 
     read (*, *) s, gen
 
-#if defined(_OFFLOAD) && defined(_CUBLAS)
+#if defined(_OFFLOAD) && defined(_CUSOLVER)
     lworkspace = 1
 #ifdef RISC
     call cusolver_handle_init_(handle)
@@ -90,14 +90,14 @@ program test_zgetrf
 
     C = A
 
-#if defined(_OFFLOAD) && defined(_CUBLAS)
+#if defined(_OFFLOAD) && defined(_CUSOLVER)
 !$omp target data map(tofrom:C,ipiv)
 #endif
     call zgetrf_(s, s&
                 &, C, s&
                 &, ipiv&
                 &, info)
-#if defined(_OFFLOAD) && defined(_CUBLAS)
+#if defined(_OFFLOAD) && defined(_CUSOLVER)
 !$omp end target data
 #endif
 
@@ -148,7 +148,7 @@ program test_zgetrf
         print *, "OK"
     end if
 
-#if defined(_OFFLOAD) && defined(_CUBLAS)
+#if defined(_OFFLOAD) && defined(_CUSOLVER)
 !$omp end target data
 #ifdef RISC
     call cusolver_handle_destroy_(handle)
@@ -159,7 +159,7 @@ program test_zgetrf
 
     deallocate (A, ipiv, temp, upper, lower, C, helper_r, helper_c)
 
-#if defined(_OFFLOAD) && defined(_CUBLAS)
+#if defined(_OFFLOAD) && defined(_CUSOLVER)
     deallocate (dev_zgetrf_workspace)
 #endif
 


### PR DESCRIPTION
In some test there ware incorrect preprocessor macros _CUBLAS instead of _CUSOLVER