### PR TITLE
Fix accessing non allocated array in prep

### DIFF
--- a/src/a_prep/freeelmod_complex_kpoints.f90
+++ b/src/a_prep/freeelmod_complex_kpoints.f90
@@ -2605,7 +2605,6 @@ contains
         !
         if (ipc .eq. 1) then
             bdim = size(molecorbl, 1)
-            bdimdo = size(molecorbldo, 1)
         else
             bdim = size(molecorbl, 1)/2
             bdimdo = size(molecorbldo, 1)/2


### PR DESCRIPTION
Prep was asking for a size of non allocated array.

Fix #50 