### PR TITLE
Fix missing declaration in zger2

### DIFF
--- a/src/d_qlapack/zger2.f
+++ b/src/d_qlapack/zger2.f
@@ -28,6 +28,8 @@ c
       COMPLEX*16 :: ONE, ZERO
       PARAMETER (ONE= (1.0D+0,0.0D+0))
       PARAMETER (ZERO= (0.0D+0,0.0D+0))
+
+      INTEGER*4 :: I, J
 c
       IF(.NOT.yes_ontarget) THEN
           CALL ZGEMM ('N','T',M, N, 2, ALPHA


### PR DESCRIPTION
Fix `zger2`. In `zger2.f` there was a missing declaration of I and J integers. It is strange because so far no compiler ever complained about it. Well it happend in offloaded code, I think `implicit none` is not properly implemented in compilers that offload to nvptx.