### PR TITLE
version info. is printed in the stand-alone .f90 programs

### DIFF
--- a/src/a_convertfort10/convertfort10.f90
+++ b/src/a_convertfort10/convertfort10.f90
@@ -121,6 +121,9 @@ program convertfort10
     nprocn = 1
     commopt_mpi = 0
 #endif
+    ! output version information
+    if (rankn .eq. 0) call print_version
+
     proc8 = nprocn
     !#ifdef __CASO
     !#else

--- a/src/a_convertfort10mol/convertfort10mol.f90
+++ b/src/a_convertfort10mol/convertfort10mol.f90
@@ -64,7 +64,7 @@ program convertfort10mol
 #endif
     ! output version information
     if (rankn .eq. 0) call print_version
-    
+
     nprocu = nprocn
     nproc_diag = nprocu
     call mpi_sub_comm_create(comm_mpi, nproc_diag, sub_comm_diag, ierr)

--- a/src/a_convertfort10mol/convertfort10mol.f90
+++ b/src/a_convertfort10mol/convertfort10mol.f90
@@ -62,6 +62,9 @@ program convertfort10mol
     end if
     !    AAA   end lines to be added
 #endif
+    ! output version information
+    if (rankn .eq. 0) call print_version
+    
     nprocu = nprocn
     nproc_diag = nprocu
     call mpi_sub_comm_create(comm_mpi, nproc_diag, sub_comm_diag, ierr)

--- a/src/a_convertfortpfaff/convertpfaff.f90
+++ b/src/a_convertfortpfaff/convertpfaff.f90
@@ -34,6 +34,9 @@ program convertpfaff
     real*8 scale_unp, angle_rot, phi_rot
     real*8, dimension(:, :), allocatable :: surot, suscra, sutry
 
+    ! output version information
+    call print_version
+    
     !reading and saving the quantities of the fort.10_in
 
     open (unit=10, file='fort.10_in', form='formatted', status='unknown')

--- a/src/a_convertfortpfaff/convertpfaff.f90
+++ b/src/a_convertfortpfaff/convertpfaff.f90
@@ -36,7 +36,7 @@ program convertpfaff
 
     ! output version information
     call print_version
-    
+
     !reading and saving the quantities of the fort.10_in
 
     open (unit=10, file='fort.10_in', form='formatted', status='unknown')

--- a/src/a_makefort10/makefort10.f90
+++ b/src/a_makefort10/makefort10.f90
@@ -110,6 +110,9 @@ program makefort10
     logical :: readunpaired, forcesymm
     real*8 scale_jasfat
 
+    ! output version information
+    call print_version
+    
     namelist /system/ natoms, posunits, nxyz, celldm, at, phase, phasedo&
             &, pbcfort10, complexfort10, real_contracted&
             &, ntyp, rs_read, write_log, axyz, nel_read, L_read, yes_pfaff&

--- a/src/a_makefort10/makefort10.f90
+++ b/src/a_makefort10/makefort10.f90
@@ -110,9 +110,6 @@ program makefort10
     logical :: readunpaired, forcesymm
     real*8 scale_jasfat
 
-    ! output version information
-    call print_version
-
     namelist /system/ natoms, posunits, nxyz, celldm, at, phase, phasedo&
             &, pbcfort10, complexfort10, real_contracted&
             &, ntyp, rs_read, write_log, axyz, nel_read, L_read, yes_pfaff&
@@ -150,6 +147,9 @@ program makefort10
         call help_online(name_tool)
         stop
     end if
+
+    ! output version information
+    call print_version
 
     write (*, *)
     write (*, *) ' * * * Creates fort.10 for solids and open systems * * * '

--- a/src/a_makefort10/makefort10.f90
+++ b/src/a_makefort10/makefort10.f90
@@ -112,7 +112,7 @@ program makefort10
 
     ! output version information
     call print_version
-    
+
     namelist /system/ natoms, posunits, nxyz, celldm, at, phase, phasedo&
             &, pbcfort10, complexfort10, real_contracted&
             &, ntyp, rs_read, write_log, axyz, nel_read, L_read, yes_pfaff&

--- a/src/a_prep/prep.f90
+++ b/src/a_prep/prep.f90
@@ -61,6 +61,10 @@ program main
     old_threads = 1
 #endif
 
+    ! output version information
+    if (rank .eq. 0) call print_version
+    
+    ! print threads and mpi info.
     if (rank .eq. 0) write (6, *) ' Number of threads /mpi proc =', old_threads
 
 #if defined UNREL_SMP

--- a/src/a_prep/prep.f90
+++ b/src/a_prep/prep.f90
@@ -63,7 +63,7 @@ program main
 
     ! output version information
     if (rank .eq. 0) call print_version
-    
+
     ! print threads and mpi info.
     if (rank .eq. 0) write (6, *) ' Number of threads /mpi proc =', old_threads
 

--- a/src/a_readforward/readforward.f90
+++ b/src/a_readforward/readforward.f90
@@ -235,7 +235,7 @@ program readforward
 
     ! output version information
     if (rank .eq. 0) call print_version
-    
+
     zero = 0.d0
     max_shells = 20000 ! max number of k-shells allowed
 

--- a/src/a_readforward/readforward.f90
+++ b/src/a_readforward/readforward.f90
@@ -233,6 +233,9 @@ program readforward
     sizep = 1
 #endif
 
+    ! output version information
+    if (rank .eq. 0) call print_version
+    
     zero = 0.d0
     max_shells = 20000 ! max number of k-shells allowed
 

--- a/src/m_common/_version.f90
+++ b/src/m_common/_version.f90
@@ -1,6 +1,6 @@
 subroutine print_version
     implicit none
-    character(LEN=6) :: version_number = '0.0.1'
+    character(LEN=6) :: version_number = '1.0.0'
     character(LEN=40) :: git_revision = 'unknown'
 
     write (6, *) "----------------------------------------------------------------------------"


### PR DESCRIPTION
The version info. is printed in the stand-alone .f90 programs

- convertfort10.f90
- convertfort10mol.f90
- convertpfaff.f90
- makefort10.f90
- prep.f90
- readforward.f90
- main.f90 (i.e., turborvb-*.x, already implemented.)