### PR TITLE
Add support for AMD compilers (only CPU)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -311,6 +311,11 @@ find_package(OpenMP)
 find_package(Threads)
 
 if(EXT_GPU)
+  if(CMAKE_Fortran_COMPILER_ID STREQUAL "Flang")
+    message( WARNING "Due to a bug in gfortran compiler, it is not possible to compile GPU version.\n"
+                     "Turning off GPU support")
+    set( EXT_GPU OFF )
+  endif()
   if(CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
     message( WARNING "Due to a bug in gfortran compiler, it is not possible to compile GPU version.\n"
                      "Turning off GPU support")
@@ -717,6 +722,11 @@ if(CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
     prepare_agressive_gnu()
     set_gnu_fortran_compiler()
   
+elseif(CMAKE_Fortran_COMPILER_ID STREQUAL "Flang")
+
+    prepare_agressive_amd()
+    set_amd_fortran_compiler()
+
 elseif(CMAKE_Fortran_COMPILER_ID STREQUAL "Intel")
 
     prepare_agressive_intel()
@@ -767,6 +777,20 @@ elseif(CMAKE_C_COMPILER_ID STREQUAL "Intel")
   
   #
   # Here Intel (legacy) part ends
+  #
+  ######################################################################
+
+elseif(CMAKE_C_COMPILER_ID STREQUAL "Clang")
+
+  ######################################################################
+  #
+  # Here amd part starts
+  #
+
+  set_amd_c_compiler()
+  
+  #
+  # Here amd part ends
   #
   ######################################################################
 
@@ -828,7 +852,7 @@ elseif(CMAKE_C_COMPILER_ID STREQUAL "AppleClang")
 
 else()
 
-    message( FATAL_ERROR "This C compiler is not supportted")
+	message( WARNING "This C compiler is not supportted")
 
 endif()
 

--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ This project uses preprocessor macros for configuration. Here are descriptions o
 - `_SIMD`: This macro forces the compiler to use more SIMD (Single Instruction, Multiple Data) instructions for parallel computing. Be cautious with this option as it may not always lead to increased performance and can make the code more complex.
 - `__FFTW`: Define this macro to enable the use of the FFTW library for Fast Fourier Transform computations.
 - `__PORT`: This macro should be defined when compiling with the Nvidia (Portland Group) Fortran compiler.
+- `__AMD`: This macro should be defined when compiling with the AMD compiler collection.
 - `__SCALAPACK`: Define this macro to enable the use of the ScaLAPACK library for linear algebra operations on distributed memory systems. Macro `PARALLEL` has to be set to on as well.
 - `__USE_INTERNAL_FFTW`: This macro is used to switch to the internal FFTW library included with the project. If this macro is defined, the project will ignore system-installed FFTW libraries and use the included one instead.
 - `PARALLEL`: Define this macro to enable compilation of the project's MPI parallelized code. MPI (Message Passing Interface) is a standardized and portable message-passing system designed to function efficiently on a wide variety of parallel computing architectures.

--- a/cmake/compilers/CMakeLists.txt
+++ b/cmake/compilers/CMakeLists.txt
@@ -19,6 +19,7 @@ add_subdirectory(intel)
 add_subdirectory(oneapi)
 add_subdirectory(ibm)
 add_subdirectory(appleclang)
+add_subdirectory(amd)
 
 #
 #####################################################################

--- a/cmake/compilers/amd/CMakeLists.txt
+++ b/cmake/compilers/amd/CMakeLists.txt
@@ -1,0 +1,143 @@
+
+macro(SET_AMD_FORTRAN_COMPILER)
+
+  ######################################################################
+  #
+  # Here AMD part starts
+  #
+
+  set( AGRESSIVE_FLAG_S "-Ofast" )
+  set( AGRESSIVE_FLAG_S "${AGRESSIVE_FLAG_S} ${EXT_AGRS}" )
+  if( ${EXT_OPT} )
+    set( PASIVE_FLAG_S "-O2" )
+  else()
+    set( PASIVE_FLAG_S "-O0" )
+  endif()
+
+  list( APPEND PPDIRECTIVES "__AMD" )
+
+  add_fortran_flag_if_avail( "-cpp"                    "GNU Fortran compiler does not supports c preprocessor" )
+  add_fortran_flag_if_avail( "-g" )
+  add_fortran_flag_if_avail( "-march=native" )
+  add_fortran_flag_if_avail( "-funroll-loops" )
+
+  if( ${EXT_OPT} )
+    add_fortran_flag_if_avail( "-fvectorize" )
+    add_fortran_flag_if_avail( "-function-specialize" )
+    add_fortran_flag_if_avail( "-finline-aggressive" )
+    add_fortran_flag_if_avail( "-ffast-math" )
+    add_fortran_flag_if_avail( "-freciprocal-math" )
+    add_fortran_flag_if_avail( "-reduce-array-computation=3" )
+    add_fortran_flag_if_avail( "-fprofile-instr-generate" )
+    add_fortran_flag_if_avail( "-fprofile-instr-use" )
+    add_fortran_flag_if_avail( "-fnt-store" )
+  endif()
+
+  add_fortran_flag_if_avail( "-openmp" )
+
+  add_link_options("-qopenmp")
+
+  # Set optimization flags:
+  foreach( LIBRARY IN LISTS LIBRARIES_S_L
+                            LIBRARIES_P_L
+                            EXECUTABLES_S_L
+                            EXECUTABLES_P_L
+                            )
+
+      get_target_property(TURBO_SOURCES ${LIBRARY} SOURCES)
+      foreach(SRC ${TURBO_SOURCES})
+        set( AGR "OFF" )
+        if(${LIBRARY} MATCHES pfapack)
+            set( AGR "ON" )
+        endif()
+        foreach(ARGSRC ${AGRESSIVE_L})
+          if(${SRC} MATCHES ".*${ARGSRC}")
+              set( AGR "ON" )
+          endif()
+        endforeach()
+        if(${AGR} AND ${EXT_OPT})
+            set_source_files_properties(${SRC} PROPERTIES COMPILE_FLAGS ${AGRESSIVE_FLAG_S})
+            if(NOT ${SRC} IN_LIST AGRESSIVE_FINAL_L)
+              list(APPEND AGRESSIVE_FINAL_L ${SRC})
+            endif()
+        else()
+            set_source_files_properties(${SRC} PROPERTIES COMPILE_FLAGS ${PASIVE_FLAG_S})
+            if(NOT ${SRC} IN_LIST PASIVE_FINAL_L)
+              list(APPEND PASIVE_FINAL_L ${SRC})
+            endif()
+        endif()
+      endforeach()
+  endforeach()
+
+  #
+  # Here GCC part ends
+  #
+  ######################################################################
+
+endmacro()
+
+macro(SET_AMD_C_COMPILER)
+
+  list( APPEND PPDIRECTIVES "__FFTW" )
+  list( APPEND PPDIRECTIVES "__USE_INTERNAL_FFTW" )
+
+  add_c_flag_if_avail( "-g" )
+  add_c_flag_if_avail( "-march=native" )
+  add_c_flag_if_avail( "-openmp" )
+
+  if( ${EXT_OPT} )
+    add_c_flag_if_avail( "-O3" )
+  else()
+    add_c_flag_if_avail( "-O0" )
+  endif()
+
+endmacro()
+
+macro( PREPARE_AGRESSIVE_AMD )
+  set(AGRESSIVE_L "")
+  list( APPEND AGRESSIVE_L 
+	  #cell.f90
+	  #dielectric.f90
+	  #ewald.f90
+      makefun.f90
+      makefun0.f90 
+      makefun_pbc.f90
+      makefun0_pbc.f90
+      makefun_bump.f90
+      makefun0_bump.f90
+      upnewwf_new.f90
+      upinvhop.f90
+      upinvhop_fnf_new.f90
+      uptabpip_new.f90
+      ratiovar.f90
+      scratchdet.f90
+      scalevect.f90
+      jastrow_exp.f90
+      jastrowgrad_exp.f90
+      jastrowgrad_exp_pbc.f90
+      up2bodypsi_pbc_exp.f90
+      upwinv.f90
+      upwinvp.f90
+      #jastrow_ei.f90
+      #jastrow_ee_exp.f90
+      conjginv_prep.f90
+      hopping_pbc.f90
+      mapping_sz.f90
+      updiag.f90
+      upsim.f90
+      upsimp.f90
+      uptable.f90
+      upvpot_pbc_exp.f90
+      t_lrdmc.f90
+      ngivej_pbc.f90
+      dgemm_my.f90
+      subener.f90
+      ratiofn_psi.f90
+      ratio_psi.f90
+      dsktri.f90
+      dsktrs.f90
+      zsktrs.f90
+      zsktri.f90
+      )
+
+endmacro()

--- a/src/a_makefort10/makefort10.f90
+++ b/src/a_makefort10/makefort10.f90
@@ -126,11 +126,23 @@ program makefort10
     write (*, *)
     write (*, *)
 #else
+#ifdef __AMD
+    namelist /electrons/ twobody, filling, noonebody, readatoms&
+            &, orbtype, nel, neldiff, numpaired, jorbtype, onlycontrdet&
+            &, onlycontrjas, shiftbeta, readunpaired, vecpbc, yesbump&
+            &, niesd, yes_crystal, yes_crystalj, no_4body_jas&
+            &, nopseudo, scale_jasfat
+    write (*, *)
+    write (*, *) ' ! ! ! WARNING DUE TO POSSIBLE BUG IN AMD COMPILER IS NOT POSSIBLE TO SET ONEBODY AND TWOBODY PAR ! ! ! '
+    write (*, *)
+    write (*, *)
+#else
     namelist /electrons/ twobody, twobodypar, filling, noonebody, readatoms&
             &, orbtype, nel, neldiff, numpaired, jorbtype, onlycontrdet&
             &, onlycontrjas, shiftbeta, readunpaired, vecpbc, yesbump&
             &, onebodypar, niesd, yes_crystal, yes_crystalj, no_4body_jas&
             &, nopseudo, scale_jasfat
+#endif
 #endif
 
     namelist /symmetries/ nosym, notra, forces_sym, notra_forces, nosym_forces&


### PR DESCRIPTION
Support for AMD compiler. Again there are problems with (one/two)bodypar variables as was the case for nvidia compilers. I dont know what is the source but automatically loading and allocating array are I think in the official language and it is used by vasp and QE, so I dont know what is the problem.