### PR TITLE
Upgraded cublas interface 

### DIFF
--- a/src/a_module_tests/test_dgemm.f90
+++ b/src/a_module_tests/test_dgemm.f90
@@ -60,6 +60,14 @@ program test_dgemm
     C = 0
 
 #if defined(_OFFLOAD) && defined(_CUBLAS)
+#ifdef RISC
+        call cublas_handle_init_()
+#else
+        call cublas_handle_init()
+#endif
+#endif
+
+#if defined(_OFFLOAD) && defined(_CUBLAS)
 !$omp target data map(to:A,B)
 !$omp target data map(from:C)
 #endif

--- a/src/a_module_tests/test_dgemm.f90
+++ b/src/a_module_tests/test_dgemm.f90
@@ -14,6 +14,7 @@
 ! along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 program test_dgemm
+    use allio, only: cublas_handle
     implicit none
 
     real*8, allocatable, dimension(:, :) :: A, B, C, C_orig
@@ -61,9 +62,9 @@ program test_dgemm
 
 #if defined(_OFFLOAD) && defined(_CUBLAS)
 #ifdef RISC
-        call cublas_handle_init_()
+        call cublas_handle_init_(cublas_handle)
 #else
-        call cublas_handle_init()
+        call cublas_handle_init(cublas_handle)
 #endif
 #endif
 

--- a/src/a_module_tests/test_dgemm_b.f90
+++ b/src/a_module_tests/test_dgemm_b.f90
@@ -80,6 +80,14 @@ program test_dgemm_b
     CB_i = CB
 
 #if defined(_OFFLOAD) && defined(_CUBLAS)
+#ifdef RISC
+        call cublas_handle_init_()
+#else
+        call cublas_handle_init()
+#endif
+#endif
+
+#if defined(_OFFLOAD) && defined(_CUBLAS)
 !$omp target data map(to:A,B)
 !$omp target data map(tofrom:AB,BB,CB)
 #endif

--- a/src/a_module_tests/test_dgemm_b.f90
+++ b/src/a_module_tests/test_dgemm_b.f90
@@ -14,6 +14,7 @@
 ! along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 program test_dgemm_b
+    use allio, only: cublas_handle
     implicit none
 
     real*8, allocatable, dimension(:, :) :: A, B, AB, BB, CB, CB_i
@@ -81,9 +82,9 @@ program test_dgemm_b
 
 #if defined(_OFFLOAD) && defined(_CUBLAS)
 #ifdef RISC
-        call cublas_handle_init_()
+        call cublas_handle_init_(cublas_handle)
 #else
-        call cublas_handle_init()
+        call cublas_handle_init(cublas_handle)
 #endif
 #endif
 

--- a/src/a_module_tests/test_dgemv.f90
+++ b/src/a_module_tests/test_dgemv.f90
@@ -14,6 +14,7 @@
 ! along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 program test_dgemv
+    use allio, only: cublas_handle
     implicit none
 
     real*8, allocatable, dimension(:, :) :: B
@@ -27,6 +28,11 @@ program test_dgemv
 
 #if defined(_OFFLOAD) && defined(_CUBLAS)
     yes_on_target = .true.
+#ifdef RISC
+        call cublas_handle_init_(cublas_handle)
+#else
+        call cublas_handle_init(cublas_handle)
+#endif
 #endif
 
     ! gen = 1 : Generate matrices

--- a/src/a_module_tests/test_dgemv_.f90
+++ b/src/a_module_tests/test_dgemv_.f90
@@ -14,6 +14,7 @@
 ! along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 program test_dgemv_
+    use allio, only: cublas_handle
     implicit none
 
     real*8, allocatable, dimension(:, :) :: B
@@ -27,6 +28,11 @@ program test_dgemv_
 
 #if defined(_OFFLOAD) && defined(_CUBLAS)
     yes_on_target = .true.
+#ifdef RISC
+        call cublas_handle_init_(cublas_handle)
+#else
+        call cublas_handle_init(cublas_handle)
+#endif
 #endif
 
     ! gen = 1 : Generate matrices

--- a/src/a_module_tests/test_dger.f90
+++ b/src/a_module_tests/test_dger.f90
@@ -17,6 +17,7 @@ program test_dger
 
 #if defined(_OFFLOAD)
     use constants, only: yes_ontarget
+    use allio, only: cublas_handle
 #endif
 
     implicit none
@@ -33,9 +34,9 @@ program test_dger
 
 #if defined(_OFFLOAD) && defined(_CUBLAS)
 #ifdef RISC
-    call cublas_handle_init_()
+    call cublas_handle_init_(cublas_handle)
 #else
-    call cublas_handle_init()
+    call cublas_handle_init(cublas_handle)
 #endif
 #endif
 

--- a/src/a_module_tests/test_dger.f90
+++ b/src/a_module_tests/test_dger.f90
@@ -31,6 +31,14 @@ program test_dger
     yes_ontarget = .true.
 #endif
 
+#if defined(_OFFLOAD) && defined(_CUBLAS)
+#ifdef RISC
+    call cublas_handle_init_()
+#else
+    call cublas_handle_init()
+#endif
+#endif
+
     read (*, *) s
 
     allocate (A(s, s))

--- a/src/a_module_tests/test_dger2.f90
+++ b/src/a_module_tests/test_dger2.f90
@@ -17,6 +17,7 @@ program test_dger2
 
 #if defined(_OFFLOAD)
     use constants, only: yes_ontarget
+    use allio, only: cublas_handle
 #endif
 
     implicit none
@@ -33,9 +34,9 @@ program test_dger2
 
 #if defined(_OFFLOAD) && defined(_CUBLAS)
 #ifdef RISC
-    call cublas_handle_init_()
+    call cublas_handle_init_(cublas_handle)
 #else
-    call cublas_handle_init()
+    call cublas_handle_init(cublas_handle)
 #endif
 #endif
 

--- a/src/a_module_tests/test_dger2.f90
+++ b/src/a_module_tests/test_dger2.f90
@@ -31,6 +31,14 @@ program test_dger2
     yes_ontarget = .true.
 #endif
 
+#if defined(_OFFLOAD) && defined(_CUBLAS)
+#ifdef RISC
+    call cublas_handle_init_()
+#else
+    call cublas_handle_init()
+#endif
+#endif
+
     read (*, *) s
 
     allocate (A(s, s))

--- a/src/a_module_tests/test_dtrsm.f90
+++ b/src/a_module_tests/test_dtrsm.f90
@@ -14,6 +14,7 @@
 ! along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 program test_dtrsm
+    use allio, only: cublas_handle
     implicit none
 
     real*8, allocatable, dimension(:, :) :: A, B, C, C_orig
@@ -23,9 +24,9 @@ program test_dtrsm
 
 #if defined(_OFFLOAD) && defined(_CUBLAS)
 #ifdef RISC
-    call cublas_handle_init_()
+    call cublas_handle_init_(cublas_handle)
 #else
-    call cublas_handle_init()
+    call cublas_handle_init(cublas_handle)
 #endif
 #endif
 

--- a/src/a_module_tests/test_dtrsm.f90
+++ b/src/a_module_tests/test_dtrsm.f90
@@ -21,6 +21,14 @@ program test_dtrsm
     integer :: s, gen, ii, jj
     character(len=1) :: uplo, side, trans
 
+#if defined(_OFFLOAD) && defined(_CUBLAS)
+#ifdef RISC
+    call cublas_handle_init_()
+#else
+    call cublas_handle_init()
+#endif
+#endif
+
     ! gen = 1 : Generate matrices
     ! gen = 0 : Compare matrices
 

--- a/src/a_module_tests/test_zgemm.f90
+++ b/src/a_module_tests/test_zgemm.f90
@@ -25,6 +25,14 @@ program test_zgemm
     character(len=1) :: first, second
     character(len=100) :: message, str_tmp1, str_tmp2
 
+#if defined(_OFFLOAD) && defined(_CUBLAS)
+#ifdef RISC
+    call cublas_handle_init_()
+#else
+    call cublas_handle_init()
+#endif
+#endif
+
     ! gen = 1 : Generate matrices
     ! gen = 0 : Compare matrices
 

--- a/src/a_module_tests/test_zgemm.f90
+++ b/src/a_module_tests/test_zgemm.f90
@@ -14,6 +14,7 @@
 ! along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 program test_zgemm
+    use allio, only: cublas_handle
     implicit none
 
     complex*16, allocatable, dimension(:, :) :: A, B, C, C_orig
@@ -27,9 +28,9 @@ program test_zgemm
 
 #if defined(_OFFLOAD) && defined(_CUBLAS)
 #ifdef RISC
-    call cublas_handle_init_()
+    call cublas_handle_init_(cublas_handle)
 #else
-    call cublas_handle_init()
+    call cublas_handle_init(cublas_handle)
 #endif
 #endif
 

--- a/src/a_module_tests/test_zgemm_b.f90
+++ b/src/a_module_tests/test_zgemm_b.f90
@@ -26,6 +26,14 @@ program test_zgemm_b
     character(len=1) :: first, second
     character(len=100) :: message, str_tmp1, str_tmp2
 
+#if defined(_OFFLOAD) && defined(_CUBLAS)
+#ifdef RISC
+    call cublas_handle_init_()
+#else
+    call cublas_handle_init()
+#endif
+#endif
+
     ! gen = 1 : Generate matrices
     ! gen = 0 : Compare matrices
 

--- a/src/a_module_tests/test_zgemm_b.f90
+++ b/src/a_module_tests/test_zgemm_b.f90
@@ -14,6 +14,7 @@
 ! along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 program test_zgemm_b
+    use allio, only: cublas_handle
     implicit none
 
     complex*16, allocatable, dimension(:, :) :: A, B, AB, BB, CB, CB_i
@@ -28,9 +29,9 @@ program test_zgemm_b
 
 #if defined(_OFFLOAD) && defined(_CUBLAS)
 #ifdef RISC
-    call cublas_handle_init_()
+    call cublas_handle_init_(cublas_handle)
 #else
-    call cublas_handle_init()
+    call cublas_handle_init(cublas_handle)
 #endif
 #endif
 

--- a/src/a_module_tests/test_zgemv.f90
+++ b/src/a_module_tests/test_zgemv.f90
@@ -14,6 +14,7 @@
 ! along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 program test_zgemv
+    use allio, only: cublas_handle
     implicit none
 
     complex*16, allocatable, dimension(:, :) :: B
@@ -32,9 +33,9 @@ program test_zgemv
 
 #if defined(_OFFLOAD) && defined(_CUBLAS)
 #ifdef RISC
-    call cublas_handle_init_()
+    call cublas_handle_init_(cublas_handle)
 #else
-    call cublas_handle_init()
+    call cublas_handle_init(cublas_handle)
 #endif
 #endif
 

--- a/src/a_module_tests/test_zgemv.f90
+++ b/src/a_module_tests/test_zgemv.f90
@@ -30,6 +30,14 @@ program test_zgemv
     yes_on_target = .true.
 #endif
 
+#if defined(_OFFLOAD) && defined(_CUBLAS)
+#ifdef RISC
+    call cublas_handle_init_()
+#else
+    call cublas_handle_init()
+#endif
+#endif
+
     ! gen = 1 : Generate matrices
     ! gen = 0 : Compare matrices
 

--- a/src/a_module_tests/test_zgemv_offload.f90
+++ b/src/a_module_tests/test_zgemv_offload.f90
@@ -23,6 +23,14 @@ program test_zgemvn_offload
     character(len=1) :: operation
     integer :: s, gen
 
+#if defined(_OFFLOAD) && defined(_CUBLAS)
+#ifdef RISC
+    call cublas_handle_init_()
+#else
+    call cublas_handle_init()
+#endif
+#endif
+
     ! gen = 1 : Generate matrices
     ! gen = 0 : Compare matrices
 

--- a/src/a_module_tests/test_zgemv_offload.f90
+++ b/src/a_module_tests/test_zgemv_offload.f90
@@ -14,6 +14,7 @@
 ! along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 program test_zgemvn_offload
+    use allio, only: cublas_handle
     implicit none
 
     complex*16, allocatable, dimension(:, :) :: B
@@ -25,9 +26,9 @@ program test_zgemvn_offload
 
 #if defined(_OFFLOAD) && defined(_CUBLAS)
 #ifdef RISC
-    call cublas_handle_init_()
+    call cublas_handle_init_(cublas_handle)
 #else
-    call cublas_handle_init()
+    call cublas_handle_init(cublas_handle)
 #endif
 #endif
 

--- a/src/a_module_tests/test_zger.f90
+++ b/src/a_module_tests/test_zger.f90
@@ -27,6 +27,14 @@ program test_zgeru
     real*8 :: one = 1.d0, zero = 0.d0
     integer :: s, ii, jj
 
+#if defined(_OFFLOAD) && defined(_CUBLAS)
+#ifdef RISC
+    call cublas_handle_init_()
+#else
+    call cublas_handle_init()
+#endif
+#endif
+
     read (*, *) s
 
     allocate (A(s, s))

--- a/src/a_module_tests/test_zger.f90
+++ b/src/a_module_tests/test_zger.f90
@@ -16,7 +16,7 @@
 program test_zgeru
 
 #if defined(_OFFLOAD)
-    use allio, only: yes_on_target
+    use allio, only: yes_on_target, cublas_handle
 #endif
 
     implicit none
@@ -29,9 +29,9 @@ program test_zgeru
 
 #if defined(_OFFLOAD) && defined(_CUBLAS)
 #ifdef RISC
-    call cublas_handle_init_()
+    call cublas_handle_init_(cublas_handle)
 #else
-    call cublas_handle_init()
+    call cublas_handle_init(cublas_handle)
 #endif
 #endif
 

--- a/src/a_module_tests/test_zger2.f90
+++ b/src/a_module_tests/test_zger2.f90
@@ -31,6 +31,14 @@ program test_zger2
     yes_ontarget = .true.
 #endif
 
+#if defined(_OFFLOAD) && defined(_CUBLAS)
+#ifdef RISC
+    call cublas_handle_init_()
+#else
+    call cublas_handle_init()
+#endif
+#endif
+
     read (*, *) s
 
     allocate (A(s, s))

--- a/src/a_module_tests/test_zger2.f90
+++ b/src/a_module_tests/test_zger2.f90
@@ -17,6 +17,7 @@ program test_zger2
 
 #if defined(_OFFLOAD)
     use constants, only: yes_ontarget
+    use allio, only: cublas_handle
 #endif
 
     implicit none
@@ -33,9 +34,9 @@ program test_zger2
 
 #if defined(_OFFLOAD) && defined(_CUBLAS)
 #ifdef RISC
-    call cublas_handle_init_()
+    call cublas_handle_init_(cublas_handle)
 #else
-    call cublas_handle_init()
+    call cublas_handle_init(cublas_handle)
 #endif
 #endif
 

--- a/src/a_module_tests/test_zgeru.f90
+++ b/src/a_module_tests/test_zgeru.f90
@@ -17,6 +17,7 @@ program test_zgeru
 
 #if defined(_OFFLOAD)
     use constants, only: yes_ontarget
+    use allio, only: cublas_handle
 #endif
 
     implicit none
@@ -33,9 +34,9 @@ program test_zgeru
 
 #if defined(_OFFLOAD) && defined(_CUBLAS)
 #ifdef RISC
-    call cublas_handle_init_()
+    call cublas_handle_init_(cublas_handle)
 #else
-    call cublas_handle_init()
+    call cublas_handle_init(cublas_handle)
 #endif
 #endif
 

--- a/src/a_module_tests/test_zgeru.f90
+++ b/src/a_module_tests/test_zgeru.f90
@@ -31,6 +31,14 @@ program test_zgeru
     yes_ontarget = .true.
 #endif
 
+#if defined(_OFFLOAD) && defined(_CUBLAS)
+#ifdef RISC
+    call cublas_handle_init_()
+#else
+    call cublas_handle_init()
+#endif
+#endif
+
     read (*, *) s
 
     allocate (A(s, s))

--- a/src/a_module_tests/test_ztrsm.f90
+++ b/src/a_module_tests/test_ztrsm.f90
@@ -22,6 +22,14 @@ program test_ztrsm
     integer :: s, gen, ii, jj
     character(len=1) :: uplo, side, trans
 
+#if defined(_OFFLOAD) && defined(_CUBLAS)
+#ifdef RISC
+    call cublas_handle_init_()
+#else
+    call cublas_handle_init()
+#endif
+#endif
+
     ! gen = 1 : Generate matrices
     ! gen = 0 : Compare matrices
 

--- a/src/a_module_tests/test_ztrsm.f90
+++ b/src/a_module_tests/test_ztrsm.f90
@@ -14,6 +14,7 @@
 ! along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 program test_ztrsm
+    use allio, only: cublas_handle
     implicit none
 
     complex*16, allocatable, dimension(:, :) :: A, B, C, C_orig
@@ -24,9 +25,9 @@ program test_ztrsm
 
 #if defined(_OFFLOAD) && defined(_CUBLAS)
 #ifdef RISC
-    call cublas_handle_init_()
+    call cublas_handle_init_(cublas_handle)
 #else
-    call cublas_handle_init()
+    call cublas_handle_init(cublas_handle)
 #endif
 #endif
 

--- a/src/a_prep/prep.f90
+++ b/src/a_prep/prep.f90
@@ -109,6 +109,13 @@ program main
     ! 4) generate scratch files for continuation.
     call Initializeall
     !
+#if defined(_OFFLOAD) && defined(_CUBLAS)
+#ifdef RISC
+        call cublas_handle_init_()
+#else
+        call cublas_handle_init()
+#endif
+#endif
     ! deallocate useless variables allocated for QMC
     ! small reallocation just to be safe
     !

--- a/src/a_prep/prep.f90
+++ b/src/a_prep/prep.f90
@@ -18,6 +18,7 @@ program main
     use setup
     use freeelmod_complex, only: self_consistent_run
     use parallel_module, only: old_threads, setup_para
+    use allio, only: cublas_handle
     implicit none
     integer, external :: omp_get_max_threads
     character(lchlen) :: path
@@ -111,9 +112,9 @@ program main
     !
 #if defined(_OFFLOAD) && defined(_CUBLAS)
 #ifdef RISC
-        call cublas_handle_init_()
+        call cublas_handle_init_(cublas_handle)
 #else
-        call cublas_handle_init()
+        call cublas_handle_init(cublas_handle)
 #endif
 #endif
     ! deallocate useless variables allocated for QMC

--- a/src/a_readforward/readforward.f90
+++ b/src/a_readforward/readforward.f90
@@ -592,6 +592,15 @@ program readforward
 #endif
 
     end if
+
+#ifdef _CUBLAS
+#ifdef RISC
+    call cublas_handle_init_()
+#else
+    call cublas_handle_init()
+#endif
+#endif
+
 #ifdef _CUSOLVER
 #ifdef RISC
     call cusolver_handle_init_(handle)

--- a/src/a_readforward/readforward.f90
+++ b/src/a_readforward/readforward.f90
@@ -40,7 +40,7 @@ program readforward
             &, commcolrep_mpi, nk, mcol, chara, charaq, wkp, molyes, add_onebody2det&
             &, ndiff, vpotsav_ee
 #ifdef _OFFLOAD
-    use allio, only: handle, dev_dgetri_workspace, dev_zgetri_workspace, ipsip, psip, jasmat, muj_c &
+    use allio, only: cublas_handle, handle, dev_dgetri_workspace, dev_zgetri_workspace, ipsip, psip, jasmat, muj_c &
     &, jasmat_c, eagp_pfaff, winv, winvj, agp, agpn, ainv, winvbar, winvjbar, ainvup&
     &, ainvdo, ldworkspace, lzworkspace, dev_info, dev_dgetrf_workspace, dev_zgetrf_workspace
 #endif
@@ -595,9 +595,9 @@ program readforward
 
 #ifdef _CUBLAS
 #ifdef RISC
-    call cublas_handle_init_()
+    call cublas_handle_init_(cublas_handle)
 #else
-    call cublas_handle_init()
+    call cublas_handle_init(cublas_handle)
 #endif
 #endif
 

--- a/src/a_turborvb/main.f90
+++ b/src/a_turborvb/main.f90
@@ -5491,9 +5491,9 @@ contains
 
 #ifdef _CUBLAS
 #ifdef RISC
-        call cublas_handle_init_()
+        call cublas_handle_init_(cublas_handle)
 #else
-        call cublas_handle_init()
+        call cublas_handle_init(cublas_handle)
 #endif
 #endif
 
@@ -8740,9 +8740,9 @@ contains
 
 #ifdef _CUBLAS
 #ifdef RISC
-        call cublas_handle_destroy_()
+        call cublas_handle_destroy_(cublas_handle)
 #else
-        call cublas_handle_destroy()
+        call cublas_handle_destroy(cublas_handle)
 #endif
 #endif
 

--- a/src/a_turborvb/main.f90
+++ b/src/a_turborvb/main.f90
@@ -5489,6 +5489,14 @@ contains
         yesmin_read = .false.
         if (molopt .ne. 0) yesmin_read = .true.
 
+#ifdef _CUBLAS
+#ifdef RISC
+        call cublas_handle_init_()
+#else
+        call cublas_handle_init()
+#endif
+#endif
+
 #ifdef _CUSOLVER
 #ifdef RISC
         call cusolver_handle_init_(handle)
@@ -8729,6 +8737,14 @@ contains
         iend_sav = iend
 
         iend = i_main
+
+#ifdef _CUBLAS
+#ifdef RISC
+        call cublas_handle_destroy_()
+#else
+        call cublas_handle_destroy()
+#endif
+#endif
 
 #ifdef _CUSOLVER
 #ifdef RISC

--- a/src/d_qlapack/dgemm_tn.f
+++ b/src/d_qlapack/dgemm_tn.f
@@ -19,6 +19,7 @@ cTL off
       SUBROUTINE DGEMM_TN(M,N,K,ALPHA,A,LDA,B,LDB,BETA,C,LDC)
 c
       USE constants, ONLY: yes_ontarget
+      USE allio, ONLY: cublas_handle
 c
       IMPLICIT NONE
 c
@@ -38,11 +39,11 @@ c
 #else
 #ifdef _CUBLAS
 #ifdef RISC
-      CALL cublas_dgemm_offload_('T','N',M,N,K,alpha,A,LDA
+      CALL cublas_dgemm_offload_(cublas_handle,'T','N',M,N,K,alpha,A,LDA
      +                          ,b,LDB,beta,c,LDC)
       CALL cudasync_
 #else
-      CALL cublas_dgemm_offload('T','N',M,N,K,alpha,A,LDA
+      CALL cublas_dgemm_offload(cublas_handle,'T','N',M,N,K,alpha,A,LDA
      +                         ,b,LDB,beta,c,LDC)
       CALL cudasync
 #endif
@@ -60,6 +61,9 @@ c
 
       SUBROUTINE DGEMM_(TRANA,TRANB,M,N,K,ALPHA,A,LDA,B,LDB,BETA,C,LDC)
 c
+      USE allio, ONLY: cublas_handle
+c
+c
       IMPLICIT NONE
 c
       REAL*8 :: A(LDA,*), B(LDB,*), C(LDC,*)
@@ -74,12 +78,12 @@ c
 #else
 #ifdef _CUBLAS
 #ifdef RISC
-      CALL cublas_dgemm_offload_(TRANA,TRANB,M,N,K,alpha,A,LDA
-     +                          ,b,LDB,beta,c,LDC)
+      CALL cublas_dgemm_offload_(cublas_handle,TRANA,TRANB,M,N,K,alpha
+     +                          ,A,LDA,,b,LDB,beta,c,LDC)
       CALL cudasync_
 #else
-      CALL cublas_dgemm_offload(TRANA,TRANB,M,N,K,alpha,A,LDA
-     +                         ,b,LDB,beta,c,LDC)
+      CALL cublas_dgemm_offload(cublas_handle,TRANA,TRANB,M,N,K,alpha
+     +                         ,A,LDA,b,LDB,beta,c,LDC)
       CALL cudasync
 #endif
 #endif
@@ -89,6 +93,8 @@ c
       END
 
       SUBROUTINE DTRSM_(SIDE,UPLO,TRANSA,DIAG,M,N,ALPHA,A,LDA,B,LDB)
+c
+      USE allio, ONLY: cublas_handle
 c
       IMPLICIT NONE
 c
@@ -102,12 +108,12 @@ c
 #else
 #ifdef _CUBLAS
 #ifdef RISC
-      CALL cublas_dtrsm_offload_(SIDE,UPLO,TRANSA,DIAG,M,N,ALPHA
-     +                          ,A,LDA,B,LDB)
+      CALL cublas_dtrsm_offload_(cublas_handle,SIDE,UPLO,TRANSA,DIAG,M,N
+     +                          ,ALPHA,,A,LDA,B,LDB)
       CALL cudasync_
 #else
-      CALL cublas_dtrsm_offload(SIDE,UPLO,TRANSA,DIAG,M,N,ALPHA
-     +                         ,A,LDA,B,LDB)
+      CALL cublas_dtrsm_offload(cublas_handle,SIDE,UPLO,TRANSA,DIAG,M,N
+     +                         ,ALPHA,A,LDA,B,LDB)
       CALL cudasync
 #endif
 #else

--- a/src/d_qlapack/dgemv.f
+++ b/src/d_qlapack/dgemv.f
@@ -18,6 +18,8 @@ cTL off
 *
       SUBROUTINE DGEMV_(trans,M,N,alpha,A,lda,X,incx,beta
      +,Y,incy,yes_ontarget)
+              
+      USE allio, ONLY: cublas_handle
 
       IMPLICIT NONE
 
@@ -40,13 +42,13 @@ cTL off
       CALL DGEMV(trans,M,N,alpha,A,lda,X,incx,beta,Y,incy)
       ELSE
 #ifdef RISC
-           CALL cublas_dgemv_offload_(trans,M,N,alpha,A,lda,X
-     +                               ,incx,beta,Y,incy)
-           CALL cudasync_
+        CALL cublas_dgemv_offload_(cublas_handle,trans,M,N,alpha,A,lda,X
+     +                            ,incx,beta,Y,incy)
+        CALL cudasync_
 #else
-           CALL cublas_dgemv_offload(trans,M,N,alpha,A,lda,X
-     +                              ,incx,beta,Y,incy)
-           CALL cudasync
+        CALL cublas_dgemv_offload(cublas_handle,trans,M,N,alpha,A,lda,X
+     +                           ,incx,beta,Y,incy)
+        CALL cudasync
 #endif
       END IF
 #else

--- a/src/d_qlapack/dger.f
+++ b/src/d_qlapack/dger.f
@@ -17,7 +17,7 @@ cTL off
 *                         All rights reserved.
 *
       SUBROUTINE DGER_(M,N,ALPHA,X,INCX,Y,INCY,A,LDA)
-      USE allio, ONLY: yes_ontarget
+      USE allio, ONLY: yes_ontarget, cublas_handle
 c
       IMPLICIT NONE
 c
@@ -34,11 +34,11 @@ c
 #ifdef _OFFLOAD
 #ifdef _CUBLAS
 #ifdef RISC
-      CALL cublas_dger_offload_(M,N,alpha,X,incx,Y
+      CALL cublas_dger_offload_(cublas_handle,M,N,alpha,X,incx,Y
      +                          ,incy,A,LDA)
       CALL cudasync_
 #else
-      CALL cublas_dger_offload(M,N,alpha,X,incx,Y
+      CALL cublas_dger_offload(cublas_handle,M,N,alpha,X,incx,Y
      +                        ,incy,A,LDA)
       CALL cudasync
 #endif

--- a/src/d_qlapack/dger2.f
+++ b/src/d_qlapack/dger2.f
@@ -18,6 +18,7 @@ cTL off
 *
       SUBROUTINE DGER2(M,N,ALPHA,X,LDX,Y,LDY,A,LDA)
       USE constants,  ONLY: yes_ontarget
+      USE allio,      ONLY: cublas_handle
 c
       IMPLICIT NONE
       REAL*8 :: ALPHA
@@ -38,12 +39,12 @@ c
 #ifdef _OFFLOAD
 #ifdef _CUBLAS
 #ifdef RISC
-      CALL cublas_dgemm_offload_('N','T',M,N,2,alpha,X,LDX,Y
-     +                          ,LDY,1.d0,A,LDA)
+      CALL cublas_dgemm_offload_(cublas_handle,'N','T',M,N,2,alpha,X,LDX
+     +                          ,Y,LDY,1.d0,A,LDA)
       CALL cudasync_
 #else
-      CALL cublas_dgemm_offload('N','T',M,N,2,alpha,X,LDX,Y
-     +                         ,LDY,1.d0,A,LDA)
+      CALL cublas_dgemm_offload(cublas_handle,'N','T',M,N,2,alpha,X,LDX
+     +                         ,Y,LDY,1.d0,A,LDA)
       CALL cudasync
 #endif
 #else

--- a/src/d_qlapack/zgemm_tn.f
+++ b/src/d_qlapack/zgemm_tn.f
@@ -19,6 +19,7 @@ cTL off
       SUBROUTINE ZGEMM_TN(M,N,K,ALPHA,A,LDA,B,LDB,BETA,C,LDC)
 c
       USE constants, ONLY: yes_ontarget
+      USE allio, ONLY: cublas_handle
 c
       IMPLICIT NONE
 c
@@ -38,11 +39,11 @@ c
 #else
 #ifdef _CUBLAS
 #ifdef RISC
-      CALL cublas_zgemm_offload_('T','N',M,N,K,alpha,A,LDA
+      CALL cublas_zgemm_offload_(cublas_handle,'T','N',M,N,K,alpha,A,LDA
      +                          ,b,LDB,beta,c,LDC)
       CALL cudasync_
 #else
-      CALL cublas_zgemm_offload('T','N',M,N,K,alpha,A,LDA
+      CALL cublas_zgemm_offload(cublas_handle,'T','N',M,N,K,alpha,A,LDA
      +                         ,b,LDB,beta,c,LDC)
       CALL cudasync
 #endif
@@ -60,6 +61,8 @@ c
 
       SUBROUTINE ZGEMM_(TRANA,TRANB,M,N,K,ALPHA,A,LDA,B,LDB,BETA,C,LDC)
 c
+      USE allio, ONLY: cublas_handle
+c
       IMPLICIT NONE
 c
       COMPLEX*16 :: A(LDA,*), B(LDB,*), C(LDC,*)
@@ -74,12 +77,12 @@ c
 #else
 #ifdef _CUBLAS
 #ifdef RISC
-      CALL cublas_zgemm_offload_(TRANA,TRANB,M,N,K,alpha,A,LDA
-     +                          ,b,LDB,beta,c,LDC)
+      CALL cublas_zgemm_offload_(cublas_handle,TRANA,TRANB,M,N,K,alpha
+     +                          ,A,LDA,b,LDB,beta,c,LDC)
       CALL cudasync_
 #else
-      CALL cublas_zgemm_offload(TRANA,TRANB,M,N,K,alpha,A,LDA
-     +                         ,b,LDB,beta,c,LDC)
+      CALL cublas_zgemm_offload(cublas_handle,TRANA,TRANB,M,N,K,alpha
+     +                         ,A,LDA,b,LDB,beta,c,LDC)
       CALL cudasync
 #endif
 #endif
@@ -89,6 +92,8 @@ c
       END
 
       SUBROUTINE ZTRSM_(SIDE,UPLO,TRANSA,DIAG,M,N,ALPHA,A,LDA,B,LDB)
+c
+      USE allio, ONLY: cublas_handle
 c
       IMPLICIT NONE
 c
@@ -102,12 +107,12 @@ c
 #else
 #ifdef _CUBLAS
 #ifdef RISC
-      CALL cublas_ztrsm_offload_(SIDE,UPLO,TRANSA,DIAG,M,N,ALPHA
-     +                          ,A,LDA,B,LDB)
+      CALL cublas_ztrsm_offload_(cublas_handle,SIDE,UPLO,TRANSA,DIAG,M,N
+     +                          ,ALPHA,A,LDA,B,LDB)
       CALL cudasync_
 #else
-      CALL cublas_ztrsm_offload(SIDE,UPLO,TRANSA,DIAG,M,N,ALPHA
-     +                         ,A,LDA,B,LDB)
+      CALL cublas_ztrsm_offload(cublas_handle,SIDE,UPLO,TRANSA,DIAG,M,N
+     +                         ,ALPHA,A,LDA,B,LDB)
       CALL cudasync
 #endif
 #else

--- a/src/d_qlapack/zgemv.f
+++ b/src/d_qlapack/zgemv.f
@@ -18,6 +18,8 @@ cTL off
 *
       SUBROUTINE ZGEMV_(trans,M,N,alpha,A,lda,X,incx,beta
      +,Y,incy,YES_ONTARGET)
+c
+      USE allio, ONLY: cublas_handle
 
       IMPLICIT NONE
 
@@ -40,12 +42,12 @@ cTL off
           CALL ZGEMV(trans,M,N,alpha,A,lda,X,incx,beta,Y,incy)
       ELSE
 #ifdef RISC
-           CALL cublas_zgemv_offload_(trans,M,N,alpha,A,lda,x
-     +,incx,beta,y,incy)
+           CALL cublas_zgemv_offload_(cublas_handle,trans,M,N,alpha
+     +                               ,A,lda,x,incx,beta,y,incy)
            CALL cudasync_
 #else
-           CALL cublas_zgemv_offload(trans,M,N,alpha,A,lda,x
-     +,incx,beta,y,incy)
+           CALL cublas_zgemv_offload(cublas_handle,trans,M,N,alpha
+     +                              ,A,lda,x,incx,beta,y,incy)
            CALL cudasync
 #endif
       END IF

--- a/src/d_qlapack/zger2.f
+++ b/src/d_qlapack/zger2.f
@@ -18,6 +18,7 @@ cTL off
 *
       SUBROUTINE ZGER2(M,N,ALPHA,X,LDX,Y,LDY,A,LDA)
       USE constants,  ONLY: yes_ontarget
+      USE allio,      ONLY: cublas_handle
 
       IMPLICIT NONE
 c
@@ -42,12 +43,12 @@ c
 #ifdef _OFFLOAD
 #ifdef _CUBLAS
 #ifdef RISC
-      CALL cublas_zgemm_offload_('N','T',M,N,2,alpha,X,LDX,Y
-     +                          ,LDY,ONE,A,LDA)
+      CALL cublas_zgemm_offload_(cublas_handle,'N','T',M,N,2,alpha,X,LDX
+     +                          Y,,LDY,ONE,A,LDA)
       CALL cudasync_
 #else
-      CALL cublas_zgemm_offload('N','T',M,N,2,alpha,X,LDX,Y
-     +                         ,LDY,ONE,A,LDA)
+      CALL cublas_zgemm_offload(cublas_handle,'N','T',M,N,2,alpha,X,LDX
+     +                         ,Y,LDY,ONE,A,LDA)
       CALL cudasync
 #endif
 #else

--- a/src/d_qlapack/zgeru.f
+++ b/src/d_qlapack/zgeru.f
@@ -17,7 +17,7 @@ cTL off
 *                         All rights reserved.
 *
       SUBROUTINE ZGERU_(M,N,ALPHA,X,INCX,Y,INCY,A,LDA)
-      USE allio, ONLY: yes_ontarget
+      USE allio, ONLY: yes_ontarget, cublas_handle
 c
       IMPLICIT NONE
 c
@@ -41,11 +41,11 @@ c
 #ifdef _OFFLOAD
 #ifdef _CUBLAS
 #ifdef RISC
-      CALL cublas_zgeru_offload_(M,N,alpha,X,incx,Y
+      CALL cublas_zgeru_offload_(cublas_handle,M,N,alpha,X,incx,Y
      +                          ,incy,A,LDA)
       CALL cudasync_
 #else
-      CALL cublas_zgeru_offload(M,N,alpha,X,incx,Y
+      CALL cublas_zgeru_offload(cublas_handle,M,N,alpha,X,incx,Y
      +                         ,incy,A,LDA)
       CALL cudasync
 #endif

--- a/src/m_common/allio.f90
+++ b/src/m_common/allio.f90
@@ -127,6 +127,7 @@ module allio
     !end added Andrea Tirelli
 
     integer*8 :: handle
+    integer*8 :: cublas_handle
     integer*4 ldworkspace, lzworkspace, dev_Info(1)
     real*8, allocatable, dimension(:) :: dev_dgetrf_workspace
     complex*16, allocatable, dimension(:) :: dev_zgetrf_workspace

--- a/src/m_common/fortran.c
+++ b/src/m_common/fortran.c
@@ -33,7 +33,7 @@ struct complex
     double im;
 };
 #ifdef _CUBLAS
-#include <cublas.h>
+#include <cublas_v2.h>
 #endif /* _CUBLAS */
 #ifdef _CUBLAS
 void cudasync_(void)
@@ -80,25 +80,31 @@ void cublas_sgemm_offload_(const char * transa, const char * transb, const int *
 #ifdef _CUBLAS
 void cublas_dgemm_offload_(const char * transa, const char * transb, const int * M, const int * N, const int * K, const double * alpha, const devptr_t * devPtrA, const int * lda, const devptr_t * devPtrB, const int * ldb, const double * beta, const devptr_t * devPtrC, const int * ldc)
 {
+	cublasHandle_t handle;
+	cublasCreate( &handle );
     #pragma omp target data use_device_ptr(devPtrA, devPtrB, devPtrC)
     {
     double * devPtrA_ = (double *) devPtrA;
     double * devPtrB_ = (double *) devPtrB;
     double * devPtrC_ = (double *) devPtrC;
-    cublasDgemm(* transa, * transb, * M, * N, * K, * alpha, devPtrA_, * lda, devPtrB_, * ldb, * beta, devPtrC_, * ldc);
+    cublasDgemm_v2(handle, * transa, * transb, * M, * N, * K, * alpha, devPtrA_, * lda, devPtrB_, * ldb, * beta, devPtrC_, * ldc);
     }
+	cublasDestroy( handle );
 }
 #endif /* _CUBLAS */
 #ifdef _CUBLAS
 void cublas_zgemm_offload_(const char * transa, const char * transb, const int * M, const int * N, const int * K, const cuDoubleComplex * alpha, const devptr_t * devPtrA, const int * lda, const devptr_t * devPtrB, const int * ldb, const cuDoubleComplex * beta, const devptr_t * devPtrC, const int * ldc)
 {
+	cublasHandle_t handle;
+	cublasCreate( &handle );
     #pragma omp target data use_device_ptr(devPtrA, devPtrB, devPtrC)
     {
     cuDoubleComplex * devPtrA_ = (cuDoubleComplex *) devPtrA;
     cuDoubleComplex * devPtrB_ = (cuDoubleComplex *) devPtrB;
     cuDoubleComplex * devPtrC_ = (cuDoubleComplex *) devPtrC;
-    cublasZgemm(* transa, * transb, * M, * N, * K, * alpha, devPtrA_, * lda, devPtrB_, * ldb, * beta, devPtrC_, * ldc);
+    cublasZgemm_v2(handle, * transa, * transb, * M, * N, * K, * alpha, devPtrA_, * lda, devPtrB_, * ldb, * beta, devPtrC_, * ldc);
     }
+	cublasDestroy( handle );
 }
 #endif /* _CUBLAS */
 #ifdef _CUBLAS

--- a/src/m_common/fortran.c
+++ b/src/m_common/fortran.c
@@ -35,16 +35,20 @@ struct complex
 };
 #ifdef _CUBLAS
 #include <cublas_v2.h>
-cublasHandle_t cublas_handle;
 #endif /* _CUBLAS */
 #ifdef _CUBLAS
-void cublas_handle_init_()
+void cublas_handle_init_(long int * handle)
 {
-	cublasCreate(&cublas_handle);
+    cublasHandle_t *h;
+    h = (cublasHandle_t*) malloc(sizeof(cublasHandle_t));
+	cublasCreate(h);
+    *handle = (long int) h;
 }
-void cublas_handle_destroy_()
+void cublas_handle_destroy_(long int * handle)
 {
-    cublasDestroy(cublas_handle);
+    cublasHandle_t *h = (cublasHandle_t *) *handle;
+    cublasDestroy(*h);
+    free(h);
 }
 #endif /* _CUBLAS */
 #ifdef _CUBLAS
@@ -94,120 +98,130 @@ cublasDiagType_t cublas_diag_type(const char * blas_diag_type)
 }
 #endif /* _CUBLAS */
 #ifdef _CUBLAS
-void cublas_dger_offload_(const int * M, const int * N, const double * alpha, const devptr_t * devPtrX, const int * incx, const devptr_t * devPtrY, const int * incy, const devptr_t * devPtrA, const int * lda)
+void cublas_dger_offload_(const long int * handle, const int * M, const int * N, const double * alpha, const devptr_t * devPtrX, const int * incx, const devptr_t * devPtrY, const int * incy, const devptr_t * devPtrA, const int * lda)
 {
+	cublasHandle_t * handle__ = (cublasHandle_t *) *handle;
     #pragma omp target data use_device_ptr(devPtrX, devPtrY, devPtrA)
     {
     double * devPtrX_ = (double *) devPtrX;
     double * devPtrY_ = (double *) devPtrY;
     double * devPtrA_ = (double *) devPtrA;
-    cublasDger(cublas_handle, * M, * N,  alpha, devPtrX_, * incx, devPtrY_, * incy, devPtrA_, * lda);
+    cublasDger(* handle__, * M, * N,  alpha, devPtrX_, * incx, devPtrY_, * incy, devPtrA_, * lda);
     }
 }
 #endif /* _CUBLAS */
 #ifdef _CUBLAS
-void cublas_zgeru_offload_(const int * M, const int * N, const cuDoubleComplex * alpha, const devptr_t * devPtrX, const int * incx, const devptr_t * devPtrY, const int * incy, const devptr_t * devPtrA, const int * lda)
+void cublas_zgeru_offload_(const long int * handle, const int * M, const int * N, const cuDoubleComplex * alpha, const devptr_t * devPtrX, const int * incx, const devptr_t * devPtrY, const int * incy, const devptr_t * devPtrA, const int * lda)
 {
+	cublasHandle_t * handle__ = (cublasHandle_t *) *handle;
     #pragma omp target data use_device_ptr(devPtrX, devPtrY, devPtrA)
     {
     cuDoubleComplex * devPtrX_ = (cuDoubleComplex *) devPtrX;
     cuDoubleComplex * devPtrY_ = (cuDoubleComplex *) devPtrY;
     cuDoubleComplex * devPtrA_ = (cuDoubleComplex *) devPtrA;
-    cublasZgeru(cublas_handle, * M, * N, alpha, devPtrX_, * incx, devPtrY_, * incy, devPtrA_, * lda);
+    cublasZgeru(* handle__, * M, * N, alpha, devPtrX_, * incx, devPtrY_, * incy, devPtrA_, * lda);
     }
 }
 #endif /* _CUBLAS */
 #ifdef _CUBLAS
-void cublas_sgemm_offload_(const char * transa, const char * transb, const int * M, const int * N, const int * K, const float * alpha, const devptr_t * devPtrA, const int * lda, const devptr_t * devPtrB, const int * ldb, const float * beta, const devptr_t * devPtrC, const int * ldc)
+void cublas_sgemm_offload_(const long int * handle, const char * transa, const char * transb, const int * M, const int * N, const int * K, const float * alpha, const devptr_t * devPtrA, const int * lda, const devptr_t * devPtrB, const int * ldb, const float * beta, const devptr_t * devPtrC, const int * ldc)
 {
+	cublasHandle_t * handle__ = (cublasHandle_t *) *handle;
     #pragma omp target data use_device_ptr(devPtrA, devPtrB, devPtrC)
     {
     float * devPtrA_ = (float *) devPtrA;
     float * devPtrB_ = (float *) devPtrB;
     float * devPtrC_ = (float *) devPtrC;
-    cublasSgemm(cublas_handle, cublas_op_type(transa), cublas_op_type(transb), * M, * N, * K, alpha, devPtrA_, * lda, devPtrB_, * ldb, beta, devPtrC_, * ldc);
+    cublasSgemm(* handle__, cublas_op_type(transa), cublas_op_type(transb), * M, * N, * K, alpha, devPtrA_, * lda, devPtrB_, * ldb, beta, devPtrC_, * ldc);
     }
 }
 #endif /* _CUBLAS */
 #ifdef _CUBLAS
-void cublas_dgemm_offload_(const char * transa, const char * transb, const int * M, const int * N, const int * K, const double * alpha, const devptr_t * devPtrA, const int * lda, const devptr_t * devPtrB, const int * ldb, const double * beta, const devptr_t * devPtrC, const int * ldc)
+void cublas_dgemm_offload_(const long int * handle, const char * transa, const char * transb, const int * M, const int * N, const int * K, const double * alpha, const devptr_t * devPtrA, const int * lda, const devptr_t * devPtrB, const int * ldb, const double * beta, const devptr_t * devPtrC, const int * ldc)
 {
+	cublasHandle_t * handle__ = (cublasHandle_t *) *handle;
     #pragma omp target data use_device_ptr(devPtrA, devPtrB, devPtrC)
     {
     double * devPtrA_ = (double *) devPtrA;
     double * devPtrB_ = (double *) devPtrB;
     double * devPtrC_ = (double *) devPtrC;
-    cublasDgemm(cublas_handle, cublas_op_type(transa), cublas_op_type(transb), * M, * N, * K, alpha, devPtrA_, * lda, devPtrB_, * ldb, beta, devPtrC_, * ldc);
+    cublasDgemm(* handle__, cublas_op_type(transa), cublas_op_type(transb), * M, * N, * K, alpha, devPtrA_, * lda, devPtrB_, * ldb, beta, devPtrC_, * ldc);
     }
 }
 #endif /* _CUBLAS */
 #ifdef _CUBLAS
-void cublas_zgemm_offload_(const char * transa, const char * transb, const int * M, const int * N, const int * K, const cuDoubleComplex * alpha, const devptr_t * devPtrA, const int * lda, const devptr_t * devPtrB, const int * ldb, const cuDoubleComplex * beta, const devptr_t * devPtrC, const int * ldc)
+void cublas_zgemm_offload_(const long int * handle, const char * transa, const char * transb, const int * M, const int * N, const int * K, const cuDoubleComplex * alpha, const devptr_t * devPtrA, const int * lda, const devptr_t * devPtrB, const int * ldb, const cuDoubleComplex * beta, const devptr_t * devPtrC, const int * ldc)
 {
+	cublasHandle_t * handle__ = (cublasHandle_t *) *handle;
     #pragma omp target data use_device_ptr(devPtrA, devPtrB, devPtrC)
     {
     cuDoubleComplex * devPtrA_ = (cuDoubleComplex *) devPtrA;
     cuDoubleComplex * devPtrB_ = (cuDoubleComplex *) devPtrB;
     cuDoubleComplex * devPtrC_ = (cuDoubleComplex *) devPtrC;
-    cublasZgemm(cublas_handle, cublas_op_type(transa), cublas_op_type(transb), * M, * N, * K, alpha, devPtrA_, * lda, devPtrB_, * ldb, beta, devPtrC_, * ldc);
+    cublasZgemm(* handle__, cublas_op_type(transa), cublas_op_type(transb), * M, * N, * K, alpha, devPtrA_, * lda, devPtrB_, * ldb, beta, devPtrC_, * ldc);
     }
 }
 #endif /* _CUBLAS */
 #ifdef _CUBLAS
-void cublas_sgemv_offload_(const char * trans, const int * M, const int * N, const float * alpha, const devptr_t * devPtrA, const int * lda, const devptr_t * devPtrX, const int * incx, const float * beta, const devptr_t * devPtrY, const int * incy)
+void cublas_sgemv_offload_(const long int * handle, const char * trans, const int * M, const int * N, const float * alpha, const devptr_t * devPtrA, const int * lda, const devptr_t * devPtrX, const int * incx, const float * beta, const devptr_t * devPtrY, const int * incy)
 {
+	cublasHandle_t * handle__ = (cublasHandle_t *) *handle;
     #pragma omp target data use_device_ptr(devPtrA, devPtrX, devPtrY)
     {
     float * devPtrA_ = (float *) devPtrA;
     float * devPtrX_ = (float *) devPtrX;
     float * devPtrY_ = (float *) devPtrY;
-    cublasSgemv(cublas_handle, cublas_op_type(trans), * M, * N, alpha, devPtrA_, * lda, devPtrX_, * incx, beta, devPtrY_, * incy);
+    cublasSgemv(* handle__, cublas_op_type(trans), * M, * N, alpha, devPtrA_, * lda, devPtrX_, * incx, beta, devPtrY_, * incy);
     }
 }
 #endif /* _CUBLAS */
 #ifdef _CUBLAS
-void cublas_dgemv_offload_(const char * trans, const int * M, const int * N, const double * alpha, const devptr_t * devPtrA, const int * lda, const devptr_t * devPtrX, const int * incx, const double * beta, const devptr_t * devPtrY, const int * incy)
+void cublas_dgemv_offload_(const long int * handle, const char * trans, const int * M, const int * N, const double * alpha, const devptr_t * devPtrA, const int * lda, const devptr_t * devPtrX, const int * incx, const double * beta, const devptr_t * devPtrY, const int * incy)
 {
+	cublasHandle_t * handle__ = (cublasHandle_t *) *handle;
     #pragma omp target data use_device_ptr(devPtrA, devPtrX, devPtrY)
     {
     double * devPtrA_ = (double *) devPtrA;
     double * devPtrX_ = (double *) devPtrX;
     double * devPtrY_ = (double *) devPtrY;
-    cublasDgemv(cublas_handle, cublas_op_type(trans), * M, * N, alpha, devPtrA_, * lda, devPtrX_, * incx, beta, devPtrY_, * incy);
+    cublasDgemv(* handle__, cublas_op_type(trans), * M, * N, alpha, devPtrA_, * lda, devPtrX_, * incx, beta, devPtrY_, * incy);
     }
 }
 #endif /* _CUBLAS */
 #ifdef _CUBLAS
-void cublas_zgemv_offload_(const char * trans, const int * M, const int * N, const cuDoubleComplex * alpha, const devptr_t * devPtrA, const int * lda, const devptr_t * devPtrX, const int * incx, const cuDoubleComplex * beta, const devptr_t * devPtrY, const int * incy)
+void cublas_zgemv_offload_(const long int * handle, const char * trans, const int * M, const int * N, const cuDoubleComplex * alpha, const devptr_t * devPtrA, const int * lda, const devptr_t * devPtrX, const int * incx, const cuDoubleComplex * beta, const devptr_t * devPtrY, const int * incy)
 {
+	cublasHandle_t * handle__ = (cublasHandle_t *) *handle;
     #pragma omp target data use_device_ptr(devPtrA, devPtrX, devPtrY)
     {
     cuDoubleComplex * devPtrA_ = (cuDoubleComplex *) devPtrA;
     cuDoubleComplex * devPtrX_ = (cuDoubleComplex *) devPtrX;
     cuDoubleComplex * devPtrY_ = (cuDoubleComplex *) devPtrY;
-    cublasZgemv(cublas_handle, cublas_op_type(trans), * M, * N, alpha, devPtrA_, * lda, devPtrX_, * incx, beta, devPtrY_, * incy);
+    cublasZgemv(* handle__, cublas_op_type(trans), * M, * N, alpha, devPtrA_, * lda, devPtrX_, * incx, beta, devPtrY_, * incy);
     }
 }
 #endif /* _CUBLAS */
 #ifdef _CUBLAS
-void cublas_dtrsm_offload_(const char * side, const char * uplo, const char * transa, const char * diag, const int * M, const int * N, const double * alpha, const devptr_t * devPtrA, const int * lda, const devptr_t * devPtrB, const int * ldb)
+void cublas_dtrsm_offload_(const long int * handle, const char * side, const char * uplo, const char * transa, const char * diag, const int * M, const int * N, const double * alpha, const devptr_t * devPtrA, const int * lda, const devptr_t * devPtrB, const int * ldb)
 {
+	cublasHandle_t * handle__ = (cublasHandle_t *) *handle;
     #pragma omp target data use_device_ptr(devPtrA, devPtrB)
     {
     double * devPtrA_ = (double *) devPtrA;
     double * devPtrB_ = (double *) devPtrB;
-    cublasDtrsm(cublas_handle, cublas_side_type(side), cublas_fill_type(uplo), cublas_op_type(transa), cublas_diag_type(diag), * M, * N, alpha, devPtrA_, * lda, devPtrB_, * ldb);
+    cublasDtrsm(* handle__, cublas_side_type(side), cublas_fill_type(uplo), cublas_op_type(transa), cublas_diag_type(diag), * M, * N, alpha, devPtrA_, * lda, devPtrB_, * ldb);
     }
 }
 #endif /* _CUBLAS */
 #ifdef _CUBLAS
-void cublas_ztrsm_offload_(const char * side, const char * uplo, const char * transa, const char * diag, const int * M, const int * N, const cuDoubleComplex * alpha, const devptr_t * devPtrA, const int * lda, const devptr_t * devPtrB, const int * ldb)
+void cublas_ztrsm_offload_(const long int * handle, const char * side, const char * uplo, const char * transa, const char * diag, const int * M, const int * N, const cuDoubleComplex * alpha, const devptr_t * devPtrA, const int * lda, const devptr_t * devPtrB, const int * ldb)
 {
+	cublasHandle_t * handle__ = (cublasHandle_t *) *handle;
     #pragma omp target data use_device_ptr(devPtrA, devPtrB)
     {
     cuDoubleComplex * devPtrA_ = (cuDoubleComplex *) devPtrA;
     cuDoubleComplex * devPtrB_ = (cuDoubleComplex *) devPtrB;
-    cublasZtrsm(cublas_handle, cublas_side_type(side), cublas_fill_type(uplo), cublas_op_type(transa), cublas_diag_type(diag), * M, * N, alpha, devPtrA_, * lda, devPtrB_, * ldb);
+    cublasZtrsm(* handle__, cublas_side_type(side), cublas_fill_type(uplo), cublas_op_type(transa), cublas_diag_type(diag), * M, * N, alpha, devPtrA_, * lda, devPtrB_, * ldb);
     }
 }
 #endif /* _CUBLAS */

--- a/src/m_common/fortran.c
+++ b/src/m_common/fortran.c
@@ -44,37 +44,46 @@ void cudasync_(void)
 #ifdef _CUBLAS
 void cublas_dger_offload_(const int * M, const int * N, const double * alpha, const devptr_t * devPtrX, const int * incx, const devptr_t * devPtrY, const int * incy, const devptr_t * devPtrA, const int * lda)
 {
+    cublasHandle_t handle;
+    cublasCreate( &handle );
     #pragma omp target data use_device_ptr(devPtrX, devPtrY, devPtrA)
     {
     double * devPtrX_ = (double *) devPtrX;
     double * devPtrY_ = (double *) devPtrY;
     double * devPtrA_ = (double *) devPtrA;
-    cublasDger(* M, * N, * alpha, devPtrX_, * incx, devPtrY_, * incy, devPtrA_, * lda);
+    cublasDger(handle, * M, * N,  alpha, devPtrX_, * incx, devPtrY_, * incy, devPtrA_, * lda);
     }
+    cublasDestroy( handle );
 }
 #endif /* _CUBLAS */
 #ifdef _CUBLAS
 void cublas_zgeru_offload_(const int * M, const int * N, const cuDoubleComplex * alpha, const devptr_t * devPtrX, const int * incx, const devptr_t * devPtrY, const int * incy, const devptr_t * devPtrA, const int * lda)
 {
+    cublasHandle_t handle;
+    cublasCreate( &handle );
     #pragma omp target data use_device_ptr(devPtrX, devPtrY, devPtrA)
     {
     cuDoubleComplex * devPtrX_ = (cuDoubleComplex *) devPtrX;
     cuDoubleComplex * devPtrY_ = (cuDoubleComplex *) devPtrY;
     cuDoubleComplex * devPtrA_ = (cuDoubleComplex *) devPtrA;
-    cublasZgeru(* M, * N, * alpha, devPtrX_, * incx, devPtrY_, * incy, devPtrA_, * lda);
+    cublasZgeru(handle, * M, * N, alpha, devPtrX_, * incx, devPtrY_, * incy, devPtrA_, * lda);
     }
+    cublasDestroy( handle );
 }
 #endif /* _CUBLAS */
 #ifdef _CUBLAS
 void cublas_sgemm_offload_(const char * transa, const char * transb, const int * M, const int * N, const int * K, const float * alpha, const devptr_t * devPtrA, const int * lda, const devptr_t * devPtrB, const int * ldb, const float * beta, const devptr_t * devPtrC, const int * ldc)
 {
+    cublasHandle_t handle;
+    cublasCreate( &handle );
     #pragma omp target data use_device_ptr(devPtrA, devPtrB, devPtrC)
     {
     float * devPtrA_ = (float *) devPtrA;
     float * devPtrB_ = (float *) devPtrB;
     float * devPtrC_ = (float *) devPtrC;
-    cublasSgemm(* transa, * transb, * M, * N, * K, * alpha, devPtrA_, * lda, devPtrB_, * ldb, * beta, devPtrC_, * ldc);
+    cublasSgemm(handle, * transa, * transb, * M, * N, * K, alpha, devPtrA_, * lda, devPtrB_, * ldb, beta, devPtrC_, * ldc);
     }
+    cublasDestroy( handle );
 }
 #endif /* _CUBLAS */
 #ifdef _CUBLAS
@@ -87,7 +96,7 @@ void cublas_dgemm_offload_(const char * transa, const char * transb, const int *
     double * devPtrA_ = (double *) devPtrA;
     double * devPtrB_ = (double *) devPtrB;
     double * devPtrC_ = (double *) devPtrC;
-    cublasDgemm_v2(handle, * transa, * transb, * M, * N, * K, * alpha, devPtrA_, * lda, devPtrB_, * ldb, * beta, devPtrC_, * ldc);
+    cublasDgemm(handle, * transa, * transb, * M, * N, * K, alpha, devPtrA_, * lda, devPtrB_, * ldb, beta, devPtrC_, * ldc);
     }
 	cublasDestroy( handle );
 }
@@ -102,7 +111,7 @@ void cublas_zgemm_offload_(const char * transa, const char * transb, const int *
     cuDoubleComplex * devPtrA_ = (cuDoubleComplex *) devPtrA;
     cuDoubleComplex * devPtrB_ = (cuDoubleComplex *) devPtrB;
     cuDoubleComplex * devPtrC_ = (cuDoubleComplex *) devPtrC;
-    cublasZgemm_v2(handle, * transa, * transb, * M, * N, * K, * alpha, devPtrA_, * lda, devPtrB_, * ldb, * beta, devPtrC_, * ldc);
+    cublasZgemm(handle, * transa, * transb, * M, * N, * K, alpha, devPtrA_, * lda, devPtrB_, * ldb, beta, devPtrC_, * ldc);
     }
 	cublasDestroy( handle );
 }
@@ -110,59 +119,74 @@ void cublas_zgemm_offload_(const char * transa, const char * transb, const int *
 #ifdef _CUBLAS
 void cublas_sgemv_offload_(const char * trans, const int * M, const int * N, const float * alpha, const devptr_t * devPtrA, const int * lda, const devptr_t * devPtrX, const int * incx, const float * beta, const devptr_t * devPtrY, const int * incy)
 {
+	cublasHandle_t handle;
+	cublasCreate( &handle );
     #pragma omp target data use_device_ptr(devPtrA, devPtrX, devPtrY)
     {
     float * devPtrA_ = (float *) devPtrA;
     float * devPtrX_ = (float *) devPtrX;
     float * devPtrY_ = (float *) devPtrY;
-    cublasSgemv(* trans, * M, * N, * alpha, devPtrA_, * lda, devPtrX_, * incx, * beta, devPtrY_, * incy);
+    cublasSgemv(handle, * trans, * M, * N, alpha, devPtrA_, * lda, devPtrX_, * incx, beta, devPtrY_, * incy);
     }
+	cublasDestroy( handle );
 }
 #endif /* _CUBLAS */
 #ifdef _CUBLAS
 void cublas_dgemv_offload_(const char * trans, const int * M, const int * N, const double * alpha, const devptr_t * devPtrA, const int * lda, const devptr_t * devPtrX, const int * incx, const double * beta, const devptr_t * devPtrY, const int * incy)
 {
+	cublasHandle_t handle;
+	cublasCreate( &handle );
     #pragma omp target data use_device_ptr(devPtrA, devPtrX, devPtrY)
     {
     double * devPtrA_ = (double *) devPtrA;
     double * devPtrX_ = (double *) devPtrX;
     double * devPtrY_ = (double *) devPtrY;
-    cublasDgemv(* trans, * M, * N, * alpha, devPtrA_, * lda, devPtrX_, * incx, * beta, devPtrY_, * incy);
+    cublasDgemv(handle, * trans, * M, * N, alpha, devPtrA_, * lda, devPtrX_, * incx, beta, devPtrY_, * incy);
     }
+	cublasDestroy( handle );
 }
 #endif /* _CUBLAS */
 #ifdef _CUBLAS
 void cublas_zgemv_offload_(const char * trans, const int * M, const int * N, const cuDoubleComplex * alpha, const devptr_t * devPtrA, const int * lda, const devptr_t * devPtrX, const int * incx, const cuDoubleComplex * beta, const devptr_t * devPtrY, const int * incy)
 {
+	cublasHandle_t handle;
+	cublasCreate( &handle );
     #pragma omp target data use_device_ptr(devPtrA, devPtrX, devPtrY)
     {
     cuDoubleComplex * devPtrA_ = (cuDoubleComplex *) devPtrA;
     cuDoubleComplex * devPtrX_ = (cuDoubleComplex *) devPtrX;
     cuDoubleComplex * devPtrY_ = (cuDoubleComplex *) devPtrY;
-    cublasZgemv(* trans, * M, * N, * alpha, devPtrA_, * lda, devPtrX_, * incx, * beta, devPtrY_, * incy);
+    cublasZgemv(handle, * trans, * M, * N, alpha, devPtrA_, * lda, devPtrX_, * incx, beta, devPtrY_, * incy);
     }
+	cublasDestroy( handle );
 }
 #endif /* _CUBLAS */
 #ifdef _CUBLAS
 void cublas_dtrsm_offload_(const char * side, const char * uplo, const char * transa, const char * diag, const int * M, const int * N, const double * alpha, const devptr_t * devPtrA, const int * lda, const devptr_t * devPtrB, const int * ldb)
 {
+	cublasHandle_t handle;
+	cublasCreate( &handle );
     #pragma omp target data use_device_ptr(devPtrA, devPtrB)
     {
     double * devPtrA_ = (double *) devPtrA;
     double * devPtrB_ = (double *) devPtrB;
-    cublasDtrsm(* side, * uplo, * transa, * diag, * M, * N, * alpha, devPtrA_, * lda, devPtrB_, * ldb);
+    cublasDtrsm(handle, * side, * uplo, * transa, * diag, * M, * N, alpha, devPtrA_, * lda, devPtrB_, * ldb);
     }
+	cublasDestroy( handle );
 }
 #endif /* _CUBLAS */
 #ifdef _CUBLAS
 void cublas_ztrsm_offload_(const char * side, const char * uplo, const char * transa, const char * diag, const int * M, const int * N, const cuDoubleComplex * alpha, const devptr_t * devPtrA, const int * lda, const devptr_t * devPtrB, const int * ldb)
 {
+	cublasHandle_t handle;
+	cublasCreate( &handle );
     #pragma omp target data use_device_ptr(devPtrA, devPtrB)
     {
     cuDoubleComplex * devPtrA_ = (cuDoubleComplex *) devPtrA;
     cuDoubleComplex * devPtrB_ = (cuDoubleComplex *) devPtrB;
-    cublasZtrsm(* side, * uplo, * transa, * diag, * M, * N, * alpha, devPtrA_, * lda, devPtrB_, * ldb);
+    cublasZtrsm(handle, * side, * uplo, * transa, * diag, * M, * N, alpha, devPtrA_, * lda, devPtrB_, * ldb);
     }
+	cublasDestroy( handle );
 }
 #endif /* _CUBLAS */
 #ifdef _CUSOLVER

--- a/src/m_common/fortran.c
+++ b/src/m_common/fortran.c
@@ -26,6 +26,7 @@
 #include <stdlib.h>
 #include <stddef.h>
 #include <ctype.h>
+#include <stdio.h>
 typedef size_t devptr_t;
 struct complex
 {
@@ -50,6 +51,7 @@ cublasOperation_t cublas_op_type(const char * blas_op_type)
     if (*blas_op_type == 't') return CUBLAS_OP_T;
     if (*blas_op_type == 'C') return CUBLAS_OP_C;
     if (*blas_op_type == 'c') return CUBLAS_OP_C;
+	printf("WARNING: unrecognized blas_op_type\n");
     return -1;
 }
 cublasSideMode_t cublas_side_type(const char * blas_side_type)
@@ -58,6 +60,7 @@ cublasSideMode_t cublas_side_type(const char * blas_side_type)
     if (*blas_side_type == 'r') return CUBLAS_SIDE_RIGHT;
     if (*blas_side_type == 'L') return CUBLAS_SIDE_LEFT;
     if (*blas_side_type == 'l') return CUBLAS_SIDE_LEFT;
+	printf("WARNING: unrecognized blas_side_type\n");
     return -1;
 }
 cublasFillMode_t cublas_fill_type(const char * blas_fill_type)
@@ -66,6 +69,7 @@ cublasFillMode_t cublas_fill_type(const char * blas_fill_type)
     if (*blas_fill_type == 'u') return CUBLAS_FILL_MODE_UPPER;
     if (*blas_fill_type == 'L') return CUBLAS_FILL_MODE_LOWER;
     if (*blas_fill_type == 'l') return CUBLAS_FILL_MODE_LOWER;
+	printf("WARNING: unrecognized blas_fill_type\n");
     return -1;
 }
 cublasDiagType_t cublas_diag_type(const char * blas_diag_type)
@@ -74,6 +78,7 @@ cublasDiagType_t cublas_diag_type(const char * blas_diag_type)
     if (*blas_diag_type == 'u') return CUBLAS_DIAG_UNIT;
     if (*blas_diag_type == 'N') return CUBLAS_DIAG_NON_UNIT;
     if (*blas_diag_type == 'n') return CUBLAS_DIAG_NON_UNIT;
+	printf("WARNING: unrecognized blas_diag_type\n");
     return -1;
 }
 #endif /* _CUBLAS */

--- a/src/m_common/fortran.c
+++ b/src/m_common/fortran.c
@@ -35,6 +35,17 @@ struct complex
 };
 #ifdef _CUBLAS
 #include <cublas_v2.h>
+cublasHandle_t cublas_handle;
+#endif /* _CUBLAS */
+#ifdef _CUBLAS
+void cublas_handle_init_()
+{
+	cublasCreate(&cublas_handle);
+}
+void cublas_handle_destroy_()
+{
+    cublasDestroy(cublas_handle);
+}
 #endif /* _CUBLAS */
 #ifdef _CUBLAS
 void cudasync_(void)
@@ -85,149 +96,119 @@ cublasDiagType_t cublas_diag_type(const char * blas_diag_type)
 #ifdef _CUBLAS
 void cublas_dger_offload_(const int * M, const int * N, const double * alpha, const devptr_t * devPtrX, const int * incx, const devptr_t * devPtrY, const int * incy, const devptr_t * devPtrA, const int * lda)
 {
-    cublasHandle_t handle;
-    cublasCreate( &handle );
     #pragma omp target data use_device_ptr(devPtrX, devPtrY, devPtrA)
     {
     double * devPtrX_ = (double *) devPtrX;
     double * devPtrY_ = (double *) devPtrY;
     double * devPtrA_ = (double *) devPtrA;
-    cublasDger(handle, * M, * N,  alpha, devPtrX_, * incx, devPtrY_, * incy, devPtrA_, * lda);
+    cublasDger(cublas_handle, * M, * N,  alpha, devPtrX_, * incx, devPtrY_, * incy, devPtrA_, * lda);
     }
-    cublasDestroy( handle );
 }
 #endif /* _CUBLAS */
 #ifdef _CUBLAS
 void cublas_zgeru_offload_(const int * M, const int * N, const cuDoubleComplex * alpha, const devptr_t * devPtrX, const int * incx, const devptr_t * devPtrY, const int * incy, const devptr_t * devPtrA, const int * lda)
 {
-    cublasHandle_t handle;
-    cublasCreate( &handle );
     #pragma omp target data use_device_ptr(devPtrX, devPtrY, devPtrA)
     {
     cuDoubleComplex * devPtrX_ = (cuDoubleComplex *) devPtrX;
     cuDoubleComplex * devPtrY_ = (cuDoubleComplex *) devPtrY;
     cuDoubleComplex * devPtrA_ = (cuDoubleComplex *) devPtrA;
-    cublasZgeru(handle, * M, * N, alpha, devPtrX_, * incx, devPtrY_, * incy, devPtrA_, * lda);
+    cublasZgeru(cublas_handle, * M, * N, alpha, devPtrX_, * incx, devPtrY_, * incy, devPtrA_, * lda);
     }
-    cublasDestroy( handle );
 }
 #endif /* _CUBLAS */
 #ifdef _CUBLAS
 void cublas_sgemm_offload_(const char * transa, const char * transb, const int * M, const int * N, const int * K, const float * alpha, const devptr_t * devPtrA, const int * lda, const devptr_t * devPtrB, const int * ldb, const float * beta, const devptr_t * devPtrC, const int * ldc)
 {
-    cublasHandle_t handle;
-    cublasCreate( &handle );
     #pragma omp target data use_device_ptr(devPtrA, devPtrB, devPtrC)
     {
     float * devPtrA_ = (float *) devPtrA;
     float * devPtrB_ = (float *) devPtrB;
     float * devPtrC_ = (float *) devPtrC;
-    cublasSgemm(handle, cublas_op_type(transa), cublas_op_type(transb), * M, * N, * K, alpha, devPtrA_, * lda, devPtrB_, * ldb, beta, devPtrC_, * ldc);
+    cublasSgemm(cublas_handle, cublas_op_type(transa), cublas_op_type(transb), * M, * N, * K, alpha, devPtrA_, * lda, devPtrB_, * ldb, beta, devPtrC_, * ldc);
     }
-    cublasDestroy( handle );
 }
 #endif /* _CUBLAS */
 #ifdef _CUBLAS
 void cublas_dgemm_offload_(const char * transa, const char * transb, const int * M, const int * N, const int * K, const double * alpha, const devptr_t * devPtrA, const int * lda, const devptr_t * devPtrB, const int * ldb, const double * beta, const devptr_t * devPtrC, const int * ldc)
 {
-	cublasHandle_t handle;
-	cublasCreate( &handle );
     #pragma omp target data use_device_ptr(devPtrA, devPtrB, devPtrC)
     {
     double * devPtrA_ = (double *) devPtrA;
     double * devPtrB_ = (double *) devPtrB;
     double * devPtrC_ = (double *) devPtrC;
-    cublasDgemm(handle, cublas_op_type(transa), cublas_op_type(transb), * M, * N, * K, alpha, devPtrA_, * lda, devPtrB_, * ldb, beta, devPtrC_, * ldc);
+    cublasDgemm(cublas_handle, cublas_op_type(transa), cublas_op_type(transb), * M, * N, * K, alpha, devPtrA_, * lda, devPtrB_, * ldb, beta, devPtrC_, * ldc);
     }
-	cublasDestroy( handle );
 }
 #endif /* _CUBLAS */
 #ifdef _CUBLAS
 void cublas_zgemm_offload_(const char * transa, const char * transb, const int * M, const int * N, const int * K, const cuDoubleComplex * alpha, const devptr_t * devPtrA, const int * lda, const devptr_t * devPtrB, const int * ldb, const cuDoubleComplex * beta, const devptr_t * devPtrC, const int * ldc)
 {
-	cublasHandle_t handle;
-	cublasCreate( &handle );
     #pragma omp target data use_device_ptr(devPtrA, devPtrB, devPtrC)
     {
     cuDoubleComplex * devPtrA_ = (cuDoubleComplex *) devPtrA;
     cuDoubleComplex * devPtrB_ = (cuDoubleComplex *) devPtrB;
     cuDoubleComplex * devPtrC_ = (cuDoubleComplex *) devPtrC;
-    cublasZgemm(handle, cublas_op_type(transa), cublas_op_type(transb), * M, * N, * K, alpha, devPtrA_, * lda, devPtrB_, * ldb, beta, devPtrC_, * ldc);
+    cublasZgemm(cublas_handle, cublas_op_type(transa), cublas_op_type(transb), * M, * N, * K, alpha, devPtrA_, * lda, devPtrB_, * ldb, beta, devPtrC_, * ldc);
     }
-	cublasDestroy( handle );
 }
 #endif /* _CUBLAS */
 #ifdef _CUBLAS
 void cublas_sgemv_offload_(const char * trans, const int * M, const int * N, const float * alpha, const devptr_t * devPtrA, const int * lda, const devptr_t * devPtrX, const int * incx, const float * beta, const devptr_t * devPtrY, const int * incy)
 {
-	cublasHandle_t handle;
-	cublasCreate( &handle );
     #pragma omp target data use_device_ptr(devPtrA, devPtrX, devPtrY)
     {
     float * devPtrA_ = (float *) devPtrA;
     float * devPtrX_ = (float *) devPtrX;
     float * devPtrY_ = (float *) devPtrY;
-    cublasSgemv(handle, cublas_op_type(trans), * M, * N, alpha, devPtrA_, * lda, devPtrX_, * incx, beta, devPtrY_, * incy);
+    cublasSgemv(cublas_handle, cublas_op_type(trans), * M, * N, alpha, devPtrA_, * lda, devPtrX_, * incx, beta, devPtrY_, * incy);
     }
-	cublasDestroy( handle );
 }
 #endif /* _CUBLAS */
 #ifdef _CUBLAS
 void cublas_dgemv_offload_(const char * trans, const int * M, const int * N, const double * alpha, const devptr_t * devPtrA, const int * lda, const devptr_t * devPtrX, const int * incx, const double * beta, const devptr_t * devPtrY, const int * incy)
 {
-	cublasHandle_t handle;
-	cublasCreate( &handle );
     #pragma omp target data use_device_ptr(devPtrA, devPtrX, devPtrY)
     {
     double * devPtrA_ = (double *) devPtrA;
     double * devPtrX_ = (double *) devPtrX;
     double * devPtrY_ = (double *) devPtrY;
-    cublasDgemv(handle, cublas_op_type(trans), * M, * N, alpha, devPtrA_, * lda, devPtrX_, * incx, beta, devPtrY_, * incy);
+    cublasDgemv(cublas_handle, cublas_op_type(trans), * M, * N, alpha, devPtrA_, * lda, devPtrX_, * incx, beta, devPtrY_, * incy);
     }
-	cublasDestroy( handle );
 }
 #endif /* _CUBLAS */
 #ifdef _CUBLAS
 void cublas_zgemv_offload_(const char * trans, const int * M, const int * N, const cuDoubleComplex * alpha, const devptr_t * devPtrA, const int * lda, const devptr_t * devPtrX, const int * incx, const cuDoubleComplex * beta, const devptr_t * devPtrY, const int * incy)
 {
-	cublasHandle_t handle;
-	cublasCreate( &handle );
     #pragma omp target data use_device_ptr(devPtrA, devPtrX, devPtrY)
     {
     cuDoubleComplex * devPtrA_ = (cuDoubleComplex *) devPtrA;
     cuDoubleComplex * devPtrX_ = (cuDoubleComplex *) devPtrX;
     cuDoubleComplex * devPtrY_ = (cuDoubleComplex *) devPtrY;
-    cublasZgemv(handle, cublas_op_type(trans), * M, * N, alpha, devPtrA_, * lda, devPtrX_, * incx, beta, devPtrY_, * incy);
+    cublasZgemv(cublas_handle, cublas_op_type(trans), * M, * N, alpha, devPtrA_, * lda, devPtrX_, * incx, beta, devPtrY_, * incy);
     }
-	cublasDestroy( handle );
 }
 #endif /* _CUBLAS */
 #ifdef _CUBLAS
 void cublas_dtrsm_offload_(const char * side, const char * uplo, const char * transa, const char * diag, const int * M, const int * N, const double * alpha, const devptr_t * devPtrA, const int * lda, const devptr_t * devPtrB, const int * ldb)
 {
-	cublasHandle_t handle;
-	cublasCreate( &handle );
     #pragma omp target data use_device_ptr(devPtrA, devPtrB)
     {
     double * devPtrA_ = (double *) devPtrA;
     double * devPtrB_ = (double *) devPtrB;
-    cublasDtrsm(handle, cublas_side_type(side), cublas_fill_type(uplo), cublas_op_type(transa), cublas_diag_type(diag), * M, * N, alpha, devPtrA_, * lda, devPtrB_, * ldb);
+    cublasDtrsm(cublas_handle, cublas_side_type(side), cublas_fill_type(uplo), cublas_op_type(transa), cublas_diag_type(diag), * M, * N, alpha, devPtrA_, * lda, devPtrB_, * ldb);
     }
-	cublasDestroy( handle );
 }
 #endif /* _CUBLAS */
 #ifdef _CUBLAS
 void cublas_ztrsm_offload_(const char * side, const char * uplo, const char * transa, const char * diag, const int * M, const int * N, const cuDoubleComplex * alpha, const devptr_t * devPtrA, const int * lda, const devptr_t * devPtrB, const int * ldb)
 {
-	cublasHandle_t handle;
-	cublasCreate( &handle );
     #pragma omp target data use_device_ptr(devPtrA, devPtrB)
     {
     cuDoubleComplex * devPtrA_ = (cuDoubleComplex *) devPtrA;
     cuDoubleComplex * devPtrB_ = (cuDoubleComplex *) devPtrB;
-    cublasZtrsm(handle, cublas_side_type(side), cublas_fill_type(uplo), cublas_op_type(transa), cublas_diag_type(diag), * M, * N, alpha, devPtrA_, * lda, devPtrB_, * ldb);
+    cublasZtrsm(cublas_handle, cublas_side_type(side), cublas_fill_type(uplo), cublas_op_type(transa), cublas_diag_type(diag), * M, * N, alpha, devPtrA_, * lda, devPtrB_, * ldb);
     }
-	cublasDestroy( handle );
 }
 #endif /* _CUBLAS */
 #ifdef _CUSOLVER

--- a/src/m_common/fortran.c
+++ b/src/m_common/fortran.c
@@ -42,6 +42,42 @@ void cudasync_(void)
 }
 #endif /* _CUBLAS */
 #ifdef _CUBLAS
+cublasOperation_t cublas_op_type(const char * blas_op_type)
+{
+    if (*blas_op_type == 'N') return CUBLAS_OP_N;
+    if (*blas_op_type == 'n') return CUBLAS_OP_N;
+    if (*blas_op_type == 'T') return CUBLAS_OP_T;
+    if (*blas_op_type == 't') return CUBLAS_OP_T;
+    if (*blas_op_type == 'C') return CUBLAS_OP_C;
+    if (*blas_op_type == 'c') return CUBLAS_OP_C;
+    return -1;
+}
+cublasSideMode_t cublas_side_type(const char * blas_side_type)
+{
+    if (*blas_side_type == 'R') return CUBLAS_SIDE_RIGHT;
+    if (*blas_side_type == 'r') return CUBLAS_SIDE_RIGHT;
+    if (*blas_side_type == 'L') return CUBLAS_SIDE_LEFT;
+    if (*blas_side_type == 'l') return CUBLAS_SIDE_LEFT;
+    return -1;
+}
+cublasFillMode_t cublas_fill_type(const char * blas_fill_type)
+{
+    if (*blas_fill_type == 'U') return CUBLAS_FILL_MODE_UPPER;
+    if (*blas_fill_type == 'u') return CUBLAS_FILL_MODE_UPPER;
+    if (*blas_fill_type == 'L') return CUBLAS_FILL_MODE_LOWER;
+    if (*blas_fill_type == 'l') return CUBLAS_FILL_MODE_LOWER;
+    return -1;
+}
+cublasDiagType_t cublas_diag_type(const char * blas_diag_type)
+{
+    if (*blas_diag_type == 'U') return CUBLAS_DIAG_UNIT;
+    if (*blas_diag_type == 'u') return CUBLAS_DIAG_UNIT;
+    if (*blas_diag_type == 'N') return CUBLAS_DIAG_NON_UNIT;
+    if (*blas_diag_type == 'n') return CUBLAS_DIAG_NON_UNIT;
+    return -1;
+}
+#endif /* _CUBLAS */
+#ifdef _CUBLAS
 void cublas_dger_offload_(const int * M, const int * N, const double * alpha, const devptr_t * devPtrX, const int * incx, const devptr_t * devPtrY, const int * incy, const devptr_t * devPtrA, const int * lda)
 {
     cublasHandle_t handle;
@@ -81,7 +117,7 @@ void cublas_sgemm_offload_(const char * transa, const char * transb, const int *
     float * devPtrA_ = (float *) devPtrA;
     float * devPtrB_ = (float *) devPtrB;
     float * devPtrC_ = (float *) devPtrC;
-    cublasSgemm(handle, * transa, * transb, * M, * N, * K, alpha, devPtrA_, * lda, devPtrB_, * ldb, beta, devPtrC_, * ldc);
+    cublasSgemm(handle, cublas_op_type(transa), cublas_op_type(transb), * M, * N, * K, alpha, devPtrA_, * lda, devPtrB_, * ldb, beta, devPtrC_, * ldc);
     }
     cublasDestroy( handle );
 }
@@ -96,7 +132,7 @@ void cublas_dgemm_offload_(const char * transa, const char * transb, const int *
     double * devPtrA_ = (double *) devPtrA;
     double * devPtrB_ = (double *) devPtrB;
     double * devPtrC_ = (double *) devPtrC;
-    cublasDgemm(handle, * transa, * transb, * M, * N, * K, alpha, devPtrA_, * lda, devPtrB_, * ldb, beta, devPtrC_, * ldc);
+    cublasDgemm(handle, cublas_op_type(transa), cublas_op_type(transb), * M, * N, * K, alpha, devPtrA_, * lda, devPtrB_, * ldb, beta, devPtrC_, * ldc);
     }
 	cublasDestroy( handle );
 }
@@ -111,7 +147,7 @@ void cublas_zgemm_offload_(const char * transa, const char * transb, const int *
     cuDoubleComplex * devPtrA_ = (cuDoubleComplex *) devPtrA;
     cuDoubleComplex * devPtrB_ = (cuDoubleComplex *) devPtrB;
     cuDoubleComplex * devPtrC_ = (cuDoubleComplex *) devPtrC;
-    cublasZgemm(handle, * transa, * transb, * M, * N, * K, alpha, devPtrA_, * lda, devPtrB_, * ldb, beta, devPtrC_, * ldc);
+    cublasZgemm(handle, cublas_op_type(transa), cublas_op_type(transb), * M, * N, * K, alpha, devPtrA_, * lda, devPtrB_, * ldb, beta, devPtrC_, * ldc);
     }
 	cublasDestroy( handle );
 }
@@ -126,7 +162,7 @@ void cublas_sgemv_offload_(const char * trans, const int * M, const int * N, con
     float * devPtrA_ = (float *) devPtrA;
     float * devPtrX_ = (float *) devPtrX;
     float * devPtrY_ = (float *) devPtrY;
-    cublasSgemv(handle, * trans, * M, * N, alpha, devPtrA_, * lda, devPtrX_, * incx, beta, devPtrY_, * incy);
+    cublasSgemv(handle, cublas_op_type(trans), * M, * N, alpha, devPtrA_, * lda, devPtrX_, * incx, beta, devPtrY_, * incy);
     }
 	cublasDestroy( handle );
 }
@@ -141,7 +177,7 @@ void cublas_dgemv_offload_(const char * trans, const int * M, const int * N, con
     double * devPtrA_ = (double *) devPtrA;
     double * devPtrX_ = (double *) devPtrX;
     double * devPtrY_ = (double *) devPtrY;
-    cublasDgemv(handle, * trans, * M, * N, alpha, devPtrA_, * lda, devPtrX_, * incx, beta, devPtrY_, * incy);
+    cublasDgemv(handle, cublas_op_type(trans), * M, * N, alpha, devPtrA_, * lda, devPtrX_, * incx, beta, devPtrY_, * incy);
     }
 	cublasDestroy( handle );
 }
@@ -156,7 +192,7 @@ void cublas_zgemv_offload_(const char * trans, const int * M, const int * N, con
     cuDoubleComplex * devPtrA_ = (cuDoubleComplex *) devPtrA;
     cuDoubleComplex * devPtrX_ = (cuDoubleComplex *) devPtrX;
     cuDoubleComplex * devPtrY_ = (cuDoubleComplex *) devPtrY;
-    cublasZgemv(handle, * trans, * M, * N, alpha, devPtrA_, * lda, devPtrX_, * incx, beta, devPtrY_, * incy);
+    cublasZgemv(handle, cublas_op_type(trans), * M, * N, alpha, devPtrA_, * lda, devPtrX_, * incx, beta, devPtrY_, * incy);
     }
 	cublasDestroy( handle );
 }
@@ -170,7 +206,7 @@ void cublas_dtrsm_offload_(const char * side, const char * uplo, const char * tr
     {
     double * devPtrA_ = (double *) devPtrA;
     double * devPtrB_ = (double *) devPtrB;
-    cublasDtrsm(handle, * side, * uplo, * transa, * diag, * M, * N, alpha, devPtrA_, * lda, devPtrB_, * ldb);
+    cublasDtrsm(handle, cublas_side_type(side), cublas_fill_type(uplo), cublas_op_type(transa), cublas_diag_type(diag), * M, * N, alpha, devPtrA_, * lda, devPtrB_, * ldb);
     }
 	cublasDestroy( handle );
 }
@@ -184,7 +220,7 @@ void cublas_ztrsm_offload_(const char * side, const char * uplo, const char * tr
     {
     cuDoubleComplex * devPtrA_ = (cuDoubleComplex *) devPtrA;
     cuDoubleComplex * devPtrB_ = (cuDoubleComplex *) devPtrB;
-    cublasZtrsm(handle, * side, * uplo, * transa, * diag, * M, * N, alpha, devPtrA_, * lda, devPtrB_, * ldb);
+    cublasZtrsm(handle, cublas_side_type(side), cublas_fill_type(uplo), cublas_op_type(transa), cublas_diag_type(diag), * M, * N, alpha, devPtrA_, * lda, devPtrB_, * ldb);
     }
 	cublasDestroy( handle );
 }


### PR DESCRIPTION
- Upgraded cublas library C interface with a handle parameter, solving conflicts with latest cusolver versions and enabling the compilation with cuda>=12.0.
- A global `cublas_handle` variable is initialized by each MPI process and used by all its cublas calls. Care needed if cublas are called inside a multi-threaded region (does not seem to be the case).
- Committing changes to the [fortran.c file](https://github.com/sissaschool/turborvb/blob/3583003819cf6e9b4bbda185bba104bf6b168544/src/m_common/fortran.c), which is supposed to be generated by the [make_wrapper.py script](https://github.com/sissaschool/turborvb/blob/3583003819cf6e9b4bbda185bba104bf6b168544/devel_tools/fortran_wraper_generator/make_wrapper.py). If the latter script is not maintained anymore, it is probably best to delete it.
- Contribution part of the EPICURE support for the EuroHPC project EHPC-EXT-2024E01-064.
