### PR TITLE
Documented _OPENMP preprocessor flag in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ This project uses preprocessor macros for configuration. Here are descriptions o
 - `__SCALAPACK`: Define this macro to enable the use of the ScaLAPACK library for linear algebra operations on distributed memory systems. Macro `PARALLEL` has to be set to on as well.
 - `__USE_INTERNAL_FFTW`: This macro is used to switch to the internal FFTW library included with the project. If this macro is defined, the project will ignore system-installed FFTW libraries and use the included one instead.
 - `PARALLEL`: Define this macro to enable compilation of the project's MPI parallelized code. MPI (Message Passing Interface) is a standardized and portable message-passing system designed to function efficiently on a wide variety of parallel computing architectures.
+- `_OPENMP`: TurboRVB automatically detects the compiler support for openMP, however this flag must be enabled by the user to let TurboRVB write the correct number of threads used in its output.
 - `RISC`: This macro should be defined when compiling with the IBM XL compiler.
 
 ## Notes & known compilation issues


### PR DESCRIPTION
When compiled for CPU only, TurboRVB detects automatically whether openmp is supported or not. However, the number of threads is always reported to be one in the output file, since the preprocessor flag _OPENMP is never enabled. The user is now warned of this behaviour in the README.