### PR TITLE
fix intialization of thread private variable

### DIFF
--- a/src/c_adjoint_backward/upvpotdiag_b.f90
+++ b/src/c_adjoint_backward/upvpotdiag_b.f90
@@ -66,6 +66,7 @@ SUBROUTINE UPVPOTDIAG_B(rkel, rkelb, nel, zeta, rion, rionb, iond,iond_cart&
 !           pot_aa=pot_aa+2.d0*zeta(i)*zeta(j)*temp0
             tempb0=2.d0*pot_aab*zeta(i)*zeta(j)
             if(tempb0.ne.0.d0) then 
+            iondb=0.d0
             call veps_b(iond(i,j),iondb,tempb0)
 !           reverse  of iond=sqrt(iond_cart**2)
            iond_cartb(:,i,j)=iond_cartb(:,i,j)+iondb*iond_cart(:,i,j)/iond(i,j)


### PR DESCRIPTION
Fix OpenMP bug in upvpotdiag_b.f90:
- thread-private variable iondb was passed to veps_b uninitialized.
- veps_b reads the second argument before updating it, so with OpenMP enabled each thread used undefined iondb and produced wrong/non-deterministic gradients.
- Fix: set iondb=0.d0 immediately before the call to veps_b inside the parallel region.
- The issue is detected by testad when OpenMP is enabled, including with OMP_NUM_THREADS=1.