### PR TITLE
Add optional namelist / parameter dump for debugging and reproducibility

### DIFF
--- a/src/a_convertfort10/convertfort10.f90
+++ b/src/a_convertfort10/convertfort10.f90
@@ -2559,9 +2559,6 @@ contains
             end if
         end if
 
-        ! print parameter values
-        call dump_parameters
-
         call checkiflagerr(iflagerr, rankn, 'ERROR reading mesh_info')
 #ifdef PARALLEL
         call mpi_bcast(nx, 1, MPI_INTEGER, 0, MPI_COMM_WORLD, ierr)
@@ -2603,6 +2600,9 @@ contains
 #endif
             stop
         end if
+
+        ! print parameter values
+        call dump_parameters
 
         mesh = nx
         mesh = mesh*ny
@@ -3795,7 +3795,7 @@ contains
       write (6,*) 'bigram               = ', bigram
       write (6,*) 'eqion                = ', eqion
       write (6,*) 'symiesup             = ', symiesup
-      write (6,*) 'wherescratch         = ', wherescratch
+      write (6,*) 'wherescratch         = ', trim(wherescratch)
       write (6,*) '==== namelist control ===='
       write (6,*) 'change_contr         = ', change_contr
       write (6,*) 'change_jas           = ', change_jas

--- a/src/a_convertfort10/convertfort10.f90
+++ b/src/a_convertfort10/convertfort10.f90
@@ -2558,6 +2558,10 @@ contains
                 write (6, *) ' Default value for buffer dimension=', nbufd
             end if
         end if
+
+        ! print parameter values
+        call dump_parameters
+
         call checkiflagerr(iflagerr, rankn, 'ERROR reading mesh_info')
 #ifdef PARALLEL
         call mpi_bcast(nx, 1, MPI_INTEGER, 0, MPI_COMM_WORLD, ierr)
@@ -3784,6 +3788,47 @@ contains
 
     end subroutine load_jasz
 
+    subroutine dump_parameters
+      implicit none
+      if (rankn.eq.0) then
+      write (6,*) '==== namelist option ===='
+      write (6,*) 'bigram               = ', bigram
+      write (6,*) 'eqion                = ', eqion
+      write (6,*) 'symiesup             = ', symiesup
+      write (6,*) 'wherescratch         = ', wherescratch
+      write (6,*) '==== namelist control ===='
+      write (6,*) 'change_contr         = ', change_contr
+      write (6,*) 'change_jas           = ', change_jas
+      write (6,*) 'double_kpgrid        = ', double_kpgrid
+      write (6,*) 'epsbas               = ', epsbas
+      write (6,*) 'epsdgel              = ', epsdgel
+      write (6,*) 'epsvpot              = ', epsvpot
+      write (6,*) 'force_real           = ', force_real
+      write (6,*) 'max_iter             = ', max_iter
+      write (6,*) 'overlap              = ', overlap
+      write (6,*) 'prec                 = ', prec
+      write (6,*) 'real_agp             = ', real_agp
+      write (6,*) 'rmax                 = ', rmax
+      write (6,*) 'rmaxinv              = ', rmaxinv
+      write (6,*) 'rmaxj                = ', rmaxj
+      write (6,*) 'scale_unp            = ', scale_unp
+      write (6,*) 'yespardiag           = ', yespardiag
+      write (6,*) '==== namelist mesh_info ===='
+      write (6,*) 'add_onebody2det      = ', add_onebody2det
+      write (6,*) 'ax                   = ', ax
+      write (6,*) 'ay                   = ', ay
+      write (6,*) 'az                   = ', az
+      write (6,*) 'nbufd                = ', nbufd
+      write (6,*) 'nx                   = ', nx
+      write (6,*) 'ny                   = ', ny
+      write (6,*) 'nz                   = ', nz
+      write (6,*) 'shift_origin         = ', shift_origin
+      write (6,*) 'shiftx               = ', shiftx
+      write (6,*) 'shifty               = ', shifty
+      write (6,*) 'shiftz               = ', shiftz
+      end if
+    end subroutine dump_parameters
+    
 end program convertfort10
 
 function tracematloc(n, over, ldo, jasmat, ldj, orbcost)

--- a/src/a_convertfort10mol/convertfort10mol.f90
+++ b/src/a_convertfort10mol/convertfort10mol.f90
@@ -273,9 +273,6 @@ program convertfort10mol
     call mpi_bcast(printoverlap, 1, MPI_LOGICAL, 0, MPI_COMM_WORLD, ierr)
 #endif
 
-    ! print parameter values
-    call dump_parameters
-    
     if (nmol .lt. neldo) then
         if (rank .eq. 0) write (6, *) ' Warning nmol>=neldo , changed to ', neldo
         nmol = neldo
@@ -294,6 +291,11 @@ program convertfort10mol
     nmolmaxw = nmolmax
 
     if (rank .eq. 0) write (6, *) ' Chosen nmolmin nmolmax =', nmolmin, nmolmax
+
+    ! print parameter values
+    call dump_parameters
+    
+    
 #ifdef _OFFLOAD
 !$omp target data map(to:mu_c)
 #endif

--- a/src/a_convertfort10mol/convertfort10mol.f90
+++ b/src/a_convertfort10mol/convertfort10mol.f90
@@ -273,6 +273,9 @@ program convertfort10mol
     call mpi_bcast(printoverlap, 1, MPI_LOGICAL, 0, MPI_COMM_WORLD, ierr)
 #endif
 
+    ! print parameter values
+    call dump_parameters
+    
     if (nmol .lt. neldo) then
         if (rank .eq. 0) write (6, *) ' Warning nmol>=neldo , changed to ', neldo
         nmol = neldo
@@ -311,4 +314,43 @@ program convertfort10mol
     call mpi_finalize(ierr)
 #endif
 
+  contains
+
+    subroutine dump_parameters
+      implicit none
+      if (rank.eq.0) then
+      write (6,*) '==== namelist control ===='
+      write (6,*) 'add_offmol           = ', add_offmol
+      write (6,*) 'add_onebody2det      = ', add_onebody2det
+      write (6,*) 'allowed_averagek     = ', allowed_averagek
+      write (6,*) 'epsbas               = ', epsbas
+      write (6,*) 'epsdgm               = ', epsdgm
+      write (6,*) 'gramyes              = ', gramyes
+      write (6,*) 'membig               = ', membig
+      write (6,*) 'molopt               = ', molopt
+      write (6,*) 'only_molecular       = ', only_molecular
+      write (6,*) 'orthoyes             = ', orthoyes
+      write (6,*) 'power                = ', power
+      write (6,*) 'weight_loc           = ', weight_loc
+      write (6,*) 'yesbig               = ', yesbig
+      write (6,*) '==== namelist mesh_info ===='
+      write (6,*) 'ax                   = ', ax
+      write (6,*) 'ay                   = ', ay
+      write (6,*) 'az                   = ', az
+      write (6,*) 'nbufd                = ', nbufd
+      write (6,*) 'nx                   = ', nx
+      write (6,*) 'ny                   = ', ny
+      write (6,*) 'nz                   = ', nz
+      write (6,*) 'shift_origin         = ', shift_origin
+      write (6,*) 'shiftx               = ', shiftx
+      write (6,*) 'shifty               = ', shifty
+      write (6,*) 'shiftz               = ', shiftz
+      write (6,*) '==== namelist molec_info ===='
+      write (6,*) 'nmol                 = ', nmol
+      write (6,*) 'nmolmax              = ', nmolmax
+      write (6,*) 'nmolmin              = ', nmolmin
+      write (6,*) 'printoverlap         = ', printoverlap
+      endif
+    end subroutine dump_parameters
+    
 end program convertfort10mol

--- a/src/a_makefort10/makefort10.f90
+++ b/src/a_makefort10/makefort10.f90
@@ -20,7 +20,8 @@ program makefort10
             &, apply_symm_to_orbitals, apply_symm_to_forces&
             &, orbmap, generate_orbidx, par_symm, read_orbitals &
             &, orbital, lsym_type, read_atoms, atomstypes, yesmolat &
-            &, yesmolatj, yesalloc_jas, atomic_jasmat, real_contracted
+            &, yesmolatj, yesalloc_jas, atomic_jasmat, real_contracted &
+            &, dump_parameters_orbital => dump_parameters
 
     implicit none
 
@@ -171,6 +172,9 @@ program makefort10
     ! reading input file and generating orthorombic
     ! cell from non-orthorombic one
     call read_input(5)
+    !
+    call dump_parameters
+    call dump_parameters_orbital
 
     orbtype = trim(orbtype)
     jorbtype = trim(jorbtype)
@@ -3340,6 +3344,85 @@ contains
         nrecj = nrecj_ok
         deallocate (recordsymj_1, recordsymj_2, lenrecj_1, lenrecj_2, jasyes_1, jasyes_2)
     end subroutine update_genjas
+
+    subroutine dump_parameters
+      implicit none
+      write (6,*) '==== namelist system ===='
+      write (6,*) 'L_read               = ', L_read
+      write (6,*) 'at                   = ', at
+      write (6,*) 'axyz                 = ', axyz
+      write (6,*) 'celldm               = ', celldm
+      write (6,*) 'complexfort10        = ', complexfort10
+      write (6,*) 'natoms               = ', natoms
+      write (6,*) 'nel_read             = ', nel_read
+      write (6,*) 'nodownpfaff          = ', nodownpfaff
+      write (6,*) 'nouppfaff            = ', nouppfaff
+      write (6,*) 'ntyp                 = ', ntyp
+      write (6,*) 'nxyz                 = ', nxyz
+      write (6,*) 'pbcfort10            = ', pbcfort10
+      write (6,*) 'phase                = ', phase
+      write (6,*) 'phasedo              = ', phasedo
+      write (6,*) 'posunits             = ', posunits
+      write (6,*) 'real_contracted      = ', real_contracted
+      write (6,*) 'rs_read              = ', rs_read
+      write (6,*) 'unit_crystal         = ', unit_crystal
+      write (6,*) 'write_log            = ', write_log
+      write (6,*) 'yes_pfaff            = ', yes_pfaff
+      write (6,*) 'yes_tilted           = ', yes_tilted
+         
+      write (6,*) '==== namelist electrons ===='
+      write (6,*) 'filling              = ', filling
+      write (6,*) 'jorbtype             = ', jorbtype
+      write (6,*) 'nel                  = ', nel
+      write (6,*) 'neldiff              = ', neldiff
+      write (6,*) 'niesd                = ', niesd
+      write (6,*) 'no_4body_jas         = ', no_4body_jas
+      write (6,*) 'noonebody            = ', noonebody
+      write (6,*) 'nopseudo             = ', nopseudo
+      write (6,*) 'numpaired            = ', numpaired
+#if defined(__PORT) || defined(__AMD)
+      ! skip onebodypar
+#else
+      write (6,*) 'onebodypar           = ', onebodypar
+#endif
+      write (6,*) 'onlycontrdet         = ', onlycontrdet
+      write (6,*) 'onlycontrjas         = ', onlycontrjas
+      write (6,*) 'orbtype              = ', orbtype
+      write (6,*) 'readatoms            = ', readatoms
+      write (6,*) 'readunpaired         = ', readunpaired
+      write (6,*) 'scale_jasfat         = ', scale_jasfat
+      write (6,*) 'shiftbeta            = ', shiftbeta
+      write (6,*) 'twobody              = ', twobody
+#if defined(__AMD)
+      ! skip twobodypar
+#else
+      write (6,*) 'twobodypar           = ', twobodypar
+#endif
+      write (6,*) 'vecpbc               = ', vecpbc
+      write (6,*) 'yes_crystal          = ', yes_crystal
+      write (6,*) 'yes_crystalj         = ', yes_crystalj
+      write (6,*) 'yesbump              = ', yesbump
+
+      write (6,*) '==== namelist symmetries ===='
+      write (6,*) 'eq_intatoms          = ', eq_intatoms
+      write (6,*) 'eqatoms              = ', eqatoms
+      write (6,*) 'forces_sym           = ', forces_sym
+      write (6,*) 'forcesymm            = ', forcesymm
+      write (6,*) 'nosym                = ', nosym
+      write (6,*) 'nosym_contr          = ', nosym_contr
+      write (6,*) 'nosym_contrj         = ', nosym_contrj
+      write (6,*) 'nosym_forces         = ', nosym_forces
+      write (6,*) 'notra                = ', notra
+      write (6,*) 'notra_forces         = ', notra_forces
+      write (6,*) 'rot_det              = ', rot_det
+      write (6,*) 'rot_jas              = ', rot_jas
+      write (6,*) 'rot_pfaff            = ', rot_pfaff
+      write (6,*) 'symmagp              = ', symmagp
+
+      ! ATOMIC_POSITIONS section
+      ! ATOMIC_SPECIES section
+      ! UNPAIRED section
+    end subroutine dump_parameters
 
 end program makefort10
 

--- a/src/a_makefort10/makefort10.f90
+++ b/src/a_makefort10/makefort10.f90
@@ -20,8 +20,7 @@ program makefort10
             &, apply_symm_to_orbitals, apply_symm_to_forces&
             &, orbmap, generate_orbidx, par_symm, read_orbitals &
             &, orbital, lsym_type, read_atoms, atomstypes, yesmolat &
-            &, yesmolatj, yesalloc_jas, atomic_jasmat, real_contracted &
-            &, dump_parameters_orbital => dump_parameters
+            &, yesmolatj, yesalloc_jas, atomic_jasmat, real_contracted
 
     implicit none
 
@@ -174,7 +173,6 @@ program makefort10
     call read_input(5)
     !
     call dump_parameters
-    call dump_parameters_orbital
 
     orbtype = trim(orbtype)
     jorbtype = trim(jorbtype)

--- a/src/a_makefort10/orbitals.f90
+++ b/src/a_makefort10/orbitals.f90
@@ -1483,6 +1483,17 @@ contains
         do i = 1, n
             z(i) = alpha*beta**(i - 1)
         end do
-    end subroutine defz
+      end subroutine defz
+
+    subroutine dump_parameters
+      implicit none
+      write (6,*) '==== namelist shells ===='
+      write (6,*) 'nshelljas            = ', nshelljas
+      write (6,*) 'nshelldet            = ', nshelldet
+      write (6,*) 'njas_hyb             = ', njas_hyb
+      write (6,*) 'ndet_hyb             = ', ndet_hyb
+      write (6,*) 'no_3body_jas         = ', no_3body_jas
+      write (6,*) 'ncut_hyb             = ', ncut_hyb
+    end subroutine dump_parameters
 
 end module mod_orbital

--- a/src/a_makefort10/orbitals.f90
+++ b/src/a_makefort10/orbitals.f90
@@ -136,6 +136,9 @@ contains
                 if (njas_hyb .gt. 0) call errore('read_orbitals', 'No jastrow shell, no jastrow hybrid!', 1)
             end if
             !
+            ! dump parameters
+            call dump_parameters(section_name)
+            !
         end do
 
         write (*, *) ' # Det Shells : ', totshelldet
@@ -1485,9 +1488,10 @@ contains
         end do
       end subroutine defz
 
-    subroutine dump_parameters
+    subroutine dump_parameters(section_name)
       implicit none
-      write (6,*) '==== namelist shells ===='
+      character(20),intent(in) :: section_name
+      write (6,*) '==== namelist shells ', trim(section_name), ' ===='
       write (6,*) 'nshelljas            = ', nshelljas
       write (6,*) 'nshelldet            = ', nshelldet
       write (6,*) 'njas_hyb             = ', njas_hyb

--- a/src/a_prep/setup.f90
+++ b/src/a_prep/setup.f90
@@ -829,6 +829,8 @@ contains
         ! write information on the calculation
         !
         call write_info
+        !
+        call dump_parameters
         ! syncronize all processors
 #ifdef  PARALLEL
         call mpi_barrier(MPI_COMM_WORLD, ierr)
@@ -1226,4 +1228,84 @@ contains
 
     end subroutine set_addresses
 
+    subroutine dump_parameters
+      implicit none
+      if (rank.eq.0) then
+
+      write (6,*) '==== namelist DFT ===='
+      write (6,*) 'bands                = ', bands
+      write (6,*) 'contracted_on        = ', contracted_on
+      write (6,*) 'corr_hartree         = ', corr_hartree
+      write (6,*) 'deltaE               = ', deltaE
+      write (6,*) 'do_hartree           = ', do_hartree
+      write (6,*) 'emax                 = ', emax
+      write (6,*) 'emin                 = ', emin
+      write (6,*) 'eps_mach             = ', eps_mach
+      write (6,*) 'epsdft               = ', epsdft
+      write (6,*) 'epsover              = ', epsover
+      write (6,*) 'epsshell             = ', epsshell
+      write (6,*) 'epssr                = ', epssr
+      write (6,*) 'fix_density          = ', fix_density
+      write (6,*) 'from_ions            = ', from_ions
+      write (6,*) 'h_charge             = ', h_charge
+      write (6,*) 'h_field              = ', h_field
+      write (6,*) 'jaccond              = ', jaccond
+      write (6,*) 'l0_at                = ', l0_at
+      write (6,*) 'linear               = ', linear
+      write (6,*) 'maxcg                = ', maxcg
+      write (6,*) 'maxit                = ', maxit
+      write (6,*) 'maxold               = ', maxold
+      write (6,*) 'memlarge             = ', memlarge
+      write (6,*) 'mincond              = ', mincond
+      write (6,*) 'minz_at              = ', minz_at
+      write (6,*) 'mixing               = ', mixing
+      write (6,*) 'mixingder            = ', mixingder
+      write (6,*) 'nc                   = ', nc
+      write (6,*) 'nelocc               = ', nelocc
+      write (6,*) 'neloccdo             = ', neloccdo
+      write (6,*) 'newj_onebody         = ', newj_onebody
+      write (6,*) 'nproc_fft            = ', nproc_fft
+      write (6,*) 'nx_at                = ', nx_at
+      write (6,*) 'nxs                  = ', nxs
+      write (6,*) 'ny_at                = ', ny_at
+      write (6,*) 'nys                  = ', nys
+      write (6,*) 'nz_at                = ', nz_at
+      write (6,*) 'nzs                  = ', nzs
+      write (6,*) 'optimize_overs       = ', optimize_overs
+      write (6,*) 'optocc               = ', optocc
+      write (6,*) 'orthodiag            = ', orthodiag
+      write (6,*) 'randspin             = ', randspin
+      write (6,*) 'rion_from            = ', rion_from
+      write (6,*) 'rmax                 = ', rmax
+      write (6,*) 'scale_hartree        = ', scale_hartree
+      write (6,*) 'scale_z              = ', scale_z
+      write (6,*) 'setj_onebody         = ', setj_onebody
+      write (6,*) 'shift_origin         = ', shift_origin
+      write (6,*) 'shiftx               = ', shiftx
+      write (6,*) 'shifty               = ', shifty
+      write (6,*) 'shiftz               = ', shiftz
+      write (6,*) 'task                 = ', task
+      write (6,*) 'try_translation      = ', try_translation
+      write (6,*) 'typedft              = ', typedft
+      write (6,*) 'typeopt              = ', typeopt
+      write (6,*) 'vmax0_in             = ', vmax0_in
+      write (6,*) 'weightcorr           = ', weightcorr
+      write (6,*) 'weightvh             = ', weightvh
+      write (6,*) 'weightxc             = ', weightxc
+      write (6,*) 'write_den            = ', write_den
+      write (6,*) 'write_matrix         = ', write_matrix
+      write (6,*) 'zero_jas             = ', zero_jas
+
+      if (compute_bands) then
+      write (6,*) '==== namelist band_structure ===='
+      write (6,*) 'deltaE               = ', deltaE
+      write (6,*) 'emax                 = ', emax
+      write (6,*) 'emin                 = ', emin
+      write (6,*) 'task                 = ', task
+      end if
+
+      end if ! rank.eq.0
+      return
+    end subroutine dump_parameters
+    
 end module setup

--- a/src/a_readforward/read_corr_fun.f90
+++ b/src/a_readforward/read_corr_fun.f90
@@ -213,6 +213,9 @@ subroutine read_corr_fun(nel, nelup, nion, iespbc, celldm, rs, cellscale &
     write (6, *) 'offset =', (offset(i), i=1, corrfun_dim)
     write (6, *) 'cutoff log wave function (shiftlog) =', shiftlog
 
+    ! dump parameters
+    call dump_parameters
+    
     if (sum(abs(offset(:))) .eq. 0.d0) then
         if (ngrid(1) .ge. 1 .and. ngrid(2) .ge. 1 .and. ngrid(3) .ge. 1) then
             write (6, *) 'Default shift offset for centering xcrysden -0.5,-0.5,-0.5 in mesh grid units'
@@ -407,12 +410,12 @@ subroutine read_corr_fun(nel, nelup, nion, iespbc, celldm, rs, cellscale &
         write (6, *) 'ell(z) =', ell(3)
     end if
 
-    !
-
     close (55)
 
-
-    ! write parameter values
+  contains
+    subroutine dump_parameters
+      implicit none
+      ! write parameter values
       write (6,*) '==== namelist simulation ===='
       write (6,*) 'decouple_files       = ', decouple_files
       write (6,*) 'decouple_k           = ', decouple_k
@@ -467,5 +470,6 @@ subroutine read_corr_fun(nel, nelup, nion, iespbc, celldm, rs, cellscale &
       write (6,*) 'sphere_radius        = ', sphere_radius
       write (6,*) 'spin_density         = ', spin_density
       write (6,*) 'structure_factor     = ', structure_factor
+    end subroutine dump_parameters
     
 end subroutine read_corr_fun

--- a/src/a_readforward/read_corr_fun.f90
+++ b/src/a_readforward/read_corr_fun.f90
@@ -411,4 +411,61 @@ subroutine read_corr_fun(nel, nelup, nion, iespbc, celldm, rs, cellscale &
 
     close (55)
 
+
+    ! write parameter values
+      write (6,*) '==== namelist simulation ===='
+      write (6,*) 'decouple_files       = ', decouple_files
+      write (6,*) 'decouple_k           = ', decouple_k
+      write (6,*) 'iopt                 = ', iopt
+      write (6,*) 'longio               = ', longio
+      write (6,*) 'ngen                 = ', ngen
+      write (6,*) '==== namelist system ===='
+      write (6,*) 'center_type          = ', center_type
+      write (6,*) 'da                   = ', da
+      write (6,*) 'ell                  = ', ell
+      write (6,*) 'extr_point           = ', extr_point
+      write (6,*) 'n_extr_points        = ', n_extr_points
+      write (6,*) 'ncell                = ', ncell
+      write (6,*) 'starting_point       = ', starting_point
+      write (6,*) '==== namelist corrfun ===='
+      write (6,*) 'allshells            = ', allshells
+      write (6,*) 'assar_cut            = ', assar_cut
+      write (6,*) 'assar_density        = ', assar_density
+      write (6,*) 'assar_parr           = ', assar_parr
+      write (6,*) 'bin_length           = ', bin_length
+      write (6,*) 'cart_axes            = ', cart_axes
+      write (6,*) 'charge_density       = ', charge_density
+      write (6,*) 'compute_spin2        = ', compute_spin2
+      write (6,*) 'corr_factors         = ', corr_factors
+      write (6,*) 'correlated_samp      = ', correlated_samp
+      write (6,*) 'corrfun_dim          = ', corrfun_dim
+      write (6,*) 'dipole_moment        = ', dipole_moment
+      write (6,*) 'fluctuations         = ', fluctuations
+      write (6,*) 'fwd_propagations     = ', fwd_propagations
+      write (6,*) 'fwd_skip             = ', fwd_skip
+      write (6,*) 'grid_points          = ', grid_points
+      write (6,*) 'ifberry              = ', ifberry
+      write (6,*) 'ifkspin              = ', ifkspin
+      write (6,*) 'initial_bin          = ', initial_bin
+      write (6,*) 'k_cutoff             = ', k_cutoff
+      write (6,*) 'kspin                = ', kspin
+      write (6,*) 'kswitch              = ', kswitch
+      write (6,*) 'new_density          = ', new_density
+      write (6,*) 'ngrid                = ', ngrid
+      write (6,*) 'noeloc               = ', noeloc
+      write (6,*) 'nswitch              = ', nswitch
+      write (6,*) 'offset               = ', offset
+      write (6,*) 'outofplane           = ', outofplane
+      write (6,*) 'pair_corr_fun        = ', pair_corr_fun
+      write (6,*) 'quasi_hole           = ', quasi_hole
+      write (6,*) 'quasi_hole_extr      = ', quasi_hole_extr
+      write (6,*) 'quasi_hole_k         = ', quasi_hole_k
+      write (6,*) 'quasi_particle       = ', quasi_particle
+      write (6,*) 'radial_grid          = ', radial_grid
+      write (6,*) 'rdf_for_atom         = ', rdf_for_atom
+      write (6,*) 'shiftlog             = ', shiftlog
+      write (6,*) 'sphere_radius        = ', sphere_radius
+      write (6,*) 'spin_density         = ', spin_density
+      write (6,*) 'structure_factor     = ', structure_factor
+    
 end subroutine read_corr_fun

--- a/src/a_tools/find_kpoints.f90
+++ b/src/a_tools/find_kpoints.f90
@@ -99,6 +99,9 @@ program find_kpoints
         go to 108
     end select
 
+    ! dump parameters
+    call dump_parameters_kpoints(0)
+    
     allocate (xkp(3, nk), wkp(nk))
     allocate (xkp_down(3, nk), wkp_down(nk))
     !

--- a/src/a_tools/orthomol.f90
+++ b/src/a_tools/orthomol.f90
@@ -163,6 +163,9 @@ program orthomol
 
     end if
 
+    ! write parameters
+    call dump_parameters
+
 #ifdef PARALLEL
     call mpi_bcast(nummol, 1, MPI_INTEGER, 0, MPI_COMM_WORLD, ierr)
     if (nummol .eq. 0) then
@@ -195,4 +198,27 @@ program orthomol
 #endif
 
     stop
+
+  contains
+
+    subroutine dump_parameters
+      implicit none
+      if (rank.eq.0) then
+      write (6,*) '==== namelist mesh_info ===='
+      write (6,*) 'ax                   = ', ax
+      write (6,*) 'ay                   = ', ay
+      write (6,*) 'az                   = ', az
+      write (6,*) 'nbufd                = ', nbufd
+      write (6,*) 'nx                   = ', nx
+      write (6,*) 'ny                   = ', ny
+      write (6,*) 'nz                   = ', nz
+      write (6,*) 'shift_origin         = ', shift_origin
+      write (6,*) 'shiftx               = ', shiftx
+      write (6,*) 'shifty               = ', shifty
+      write (6,*) 'shiftz               = ', shiftz
+      write (6,*) '==== namelist molec_info ===='
+      write (6,*) 'nummol               = ', nummol
+      end if
+    end subroutine dump_parameters
+      
 end

--- a/src/b_complex/read_datas.f90
+++ b/src/b_complex/read_datas.f90
@@ -2630,275 +2630,311 @@ subroutine read_datasmin
         tcore(1) = 0.d0
         icore = 0
     end if
+
+    ! write parameter values
+    call dump_parameters_simulation
+    call dump_parameters_pseudo
+    if (itest.eq.2) then
+       call dump_parameters_vmc
+    end if
+    if (itest .eq. 1 .or. itestr4 .eq. -7) then
+       call dump_parameters_dmclrdmc
+    end if
+    if (itestr .eq. -5) then
+       call dump_parameters_optimization
+    end if
+    call dump_parameters_readio
+    call dump_parameters_parameters
+    if (developer .gt. 0) then
+       call dump_parameters_unused
+    end if
+    !call dump_parameters_pot_ext
+    if (link_atom) then
+       call dump_parameters_link
+    end if
+    if (iesfree .lt. 0 .or. iessw .lt. 0 .or. iesinv .lt. 0) then
+       call dump_parameters_fitpar
+    end if
+    if (idyn .ne. 0) then
+       call dump_parameters_dynamic
+    end if
+    if (manyfort10 .and. nbead .le. 1) then
+       call dump_parameters_kpoints(rank)
+    end if
+     
 end subroutine read_datasmin
 
 subroutine read_datasmin_mol
-    use allio
-    use convertmod, only: nmolmatdo
-    implicit none
+  use allio
+  use convertmod, only: nmolmatdo
+  implicit none
 
 #ifdef PARALLEL
-    include 'mpif.h'
+  include 'mpif.h'
 #endif
-    if (itestr .eq. -5 .or. read_molecul) then
-!
+  if (itestr .eq. -5 .or. read_molecul) then
+     !
 
-        if (rank .eq. 0) then
-!       default values
-            epsdgm = 1d-14 !  No more than 12 digits in diagonalization.
-            smearing = 1d-5
-            nbufd = -1
-!       nmol=molecular-(nelup-neldo)
-            nmolmax = 0
-            nmolmaxw = 0
-            nmolmin = 0
-            nx = 0
-            ny = 0
-            nz = 0
-            ax = 0.d0
-            ay = 0.d0
-            az = 0.d0
-            weight_loc = -1.d0
-            orthoyes = .true.
-            gramyes = .true.
-            iflagerr = 1
-            if (npsar .gt. 0) then
-                add_onebody2det = .false.
-            else
-                add_onebody2det = .true.
-            end if
-            epsrem_contr = epsdgel
-            shift_origin = .true.
-            shiftx = .false.
-            shifty = .false.
-            shiftz = .false.
-            read (5, nml=molecul, err=121)
-            write (6, *) ' After reading molecul '
-            if (yesavopt) then
-                if (rank .eq. 0) write (6, *) ' Warning yesavopt forced to false with mol optimiz.!!! '
-                yesavopt = .false.
-            end if
-            iflagerr = 0
-            if (molecular .eq. 0) then
-                write (6, *) ' Warning   fort.10 should have molecular orbitals,&
-              & please run again with the output fort.10  !'
-                if (nmol .eq. -1 .or. nmol .lt. neldo) then
-                    iflagerr = 1
-                    write (6, *) ' ERROR you should have molecular orbitals in fort.10 '
-                    write (6, *) ' ERROR please use convertfort10mol or rerun with nmol>neldo '
-                end if
-            end if
-            if (contraction .eq. 0) then
-                iflagerr = 1
-                write (6, *) ' ERROR you should have contracted orbitals in fort.10 '
-                write (6, *) ' ERROR please introduce contraction (even fake) in your AGP '
-            end if
-
-121         if (iflagerr .ne. 0) then
-                write (6, *) ' ERROR reading molecul '
-                iflagerrall = iflagerr + iflagerrall
-            else
-                if (ny .eq. 0) then
-                    ny = nx
-                    write (6, *) ' Default value for ny=', ny
-                end if
-                if (nz .eq. 0) then
-                    nz = ny
-                    write (6, *) ' Default value for nz=', nz
-                end if
-                if (.not. iespbc) then
-                    if (ay .eq. 0.d0) then
-                        ay = ax
-                        write (6, *) ' Default value for ay=', ay
-                    end if
-                    if (az .eq. 0.d0) then
-                        az = ay
-                        write (6, *) ' Default value for az=', az
-                    end if
-                end if
-                if (symmagp .and. ipc .eq. 1) then
-                    nmol = molecular - ndiff
-                else
-                    nmol = (molecular - ndiff)/2
-                end if
-                write (6, *) ' Default value of nmol ', nmol
-                if (nmolmin .eq. 0) then
-                    nmolmin = neldo
-                    write (6, *) ' Default value of nmolmin ', nmolmin
-                end if
-                if (nmolmax .eq. 0) then
-                    nmolmax = neldo
-                    write (6, *) ' Default value of nmolmax ', nmolmax
-                end if
-
-                write (6, *) ' after  read molec '
-
-                if (weight_loc .eq. 0.d0) then
-                    if (epsdgm .ne. 0.d0) then
-                        weight_loc = epsdgm**2
-                    else
-                        weight_loc = 1d-8
-                    end if
-                    write (6, *) ' Default value for weight_loc =', weight_loc
-                end if
-
-                if (nmol .ne. 0 .and. nmolmax .eq. 0) then
-                    nmolmax = nmol
-                    write (6, *) ' Default value for nmolmax =', nmolmax
-                end if
-
-                if (nmolmaxw .eq. 0) then
-                    nmolmaxw = nmolmax
-                    write (6, *) ' Default value of nmolmaxw=', nmolmaxw
-                end if
-
-                if (nmolmax .lt. neldo) then
-                    iflagerrall = iflagerrall + 1
-                    write (6, *) ' Too small  nmolmax> =', neldo
-                end if
-
-!       read(5,*) epsdgm
-                write (6, *) ' error converter  ', epsdgm
-!       read(5,*) nx,ny,nz
-                write (6, *) ' # mesh read ', nx, ny, nz
-
-                if (nbufd .eq. -1) then
-#ifdef __SCALAPACK
-                    if (nelorb .gt. 2000 .and. .not. yesdft) then ! with SCALAPACK no memory problem
-#else
-                        if (nelorb .gt. 2000) then
-#endif
-                            nbufd = 100 ! there may be memory problems
-                        else
-                            nbufd = 1000 ! almost maximum efficiency dgemm
-                        end if
-                        write (6, *) 'Default value for buffer =', nbufd
-                    end if
-
-                end if
-
-            end if ! endif rank.eq.0
-
-!       never print the overlap in this case
-            printoverlap = .false.
-
-#ifdef PARALLEL
-            call mpi_bcast(epsdgm, 1, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
-            call mpi_bcast(smearing, 1, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
-            call mpi_bcast(epsrem_contr, 1, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
-            call mpi_bcast(weight_loc, 1, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
-            call mpi_bcast(nx, 1, MPI_INTEGER, 0, MPI_COMM_WORLD, ierr)
-            call mpi_bcast(ny, 1, MPI_INTEGER, 0, MPI_COMM_WORLD, ierr)
-            call mpi_bcast(nz, 1, MPI_INTEGER, 0, MPI_COMM_WORLD, ierr)
-            call mpi_bcast(nbufd, 1, MPI_INTEGER, 0, MPI_COMM_WORLD, ierr)
-            call mpi_bcast(orthoyes, 1, MPI_LOGICAL, 0, MPI_COMM_WORLD, ierr)
-            call mpi_bcast(gramyes, 1, MPI_LOGICAL, 0, MPI_COMM_WORLD, ierr)
-            call mpi_bcast(add_onebody2det, 1, MPI_LOGICAL, 0, MPI_COMM_WORLD, ierr)
-            call mpi_bcast(shift_origin, 1, MPI_LOGICAL, 0, MPI_COMM_WORLD, ierr)
-            call mpi_bcast(shiftx, 1, MPI_LOGICAL, 0, MPI_COMM_WORLD, ierr)
-            call mpi_bcast(shifty, 1, MPI_LOGICAL, 0, MPI_COMM_WORLD, ierr)
-            call mpi_bcast(shiftz, 1, MPI_LOGICAL, 0, MPI_COMM_WORLD, ierr)
-            call mpi_bcast(iflagerr, 1, MPI_INTEGER, 0, MPI_COMM_WORLD, ierr)
-            call mpi_bcast(nw_max, 1, MPI_INTEGER, 0, MPI_COMM_WORLD, ierr)
-#ifdef UNREL
-!   For unreliable  networks.
-            call mpi_barrier(MPI_COMM_WORLD, ierr)
-!$omp barrier
-#endif
-#endif
-
-            if (iessw .eq. 0 .and. iesup .eq. 0 .and. .not. yesdft .and. .not. read_molecul) then
-                call checkiflagerr(1, rank,&
-            &' ERROR you cannot use molopt>0 without optimizing AGP !!!')
-            end if
-
-            if (nx .eq. 0 .or. ny .eq. 0 .or. nz .eq. 0) then
-                write (errmsg, *) ' Mesh should be finite !!!', nx, ny, nz
-                call checkiflagerr(1, rank, errmsg)
-            end if
-
-            if (gramyes .and. .not. orthoyes) then
-                if (rank .eq. 0) write (6, *) &
-         &' Warning with Gram-Schmidt ortho, changed orthoyes= true'
-                orthoyes = .true.
-            end if
-            if (iespbc) then
-                ax = cellscale(1)/nx
-                ay = cellscale(2)/ny
-                az = cellscale(3)/nz
-                if (rank .eq. 0)                                                  &
-            &write (6, *) ' lattice mesh chosen ', ax, ay, az, cellscale(1)
-            else
-                if (rank .eq. 0) write (6, *) ' lattice mesh read ax,ay,az ', ax, ay, az
-!       if(rank.eq.0) read(5,*) ax,ay,az
-#ifdef PARALLEL
-                call mpi_bcast(ax, 1, MPI_DOUBLE_PRECISION                        &
-             &, 0, MPI_COMM_WORLD, ierr)
-                call mpi_bcast(ay, 1, MPI_DOUBLE_PRECISION                        &
-             &, 0, MPI_COMM_WORLD, ierr)
-                call mpi_bcast(az, 1, MPI_DOUBLE_PRECISION                        &
-             &, 0, MPI_COMM_WORLD, ierr)
-#ifdef UNREL
-!   For unreliable  networks.
-                call mpi_barrier(MPI_COMM_WORLD, ierr)
-!$omp barrier
-#endif
-#endif
-            end if
-            if (ax .eq. 0 .or. ay .eq. 0 .or. az .eq. 0) then
-                write (errmsg, *) ' Lattice constants should be finite !!!', ax, ay, az
-                call checkiflagerr(1, rank, errmsg)
-            end if
-
-            if (rank .eq. 0) then
-                write (6, *) '# molecular orbital Det considered/projected'
-                write (6, *) nmol, nmolmin, nmolmax
-            end if
-
-#ifdef PARALLEL
-            call mpi_bcast(nmol, 1, MPI_INTEGER                               &
-         &, 0, MPI_COMM_WORLD, ierr)
-            call mpi_bcast(nmolmin, 1, MPI_INTEGER                            &
-         &, 0, MPI_COMM_WORLD, ierr)
-            call mpi_bcast(nmolmax, 1, MPI_INTEGER                            &
-         &, 0, MPI_COMM_WORLD, ierr)
-            call mpi_bcast(nmolmaxw, 1, MPI_INTEGER                            &
-         &, 0, MPI_COMM_WORLD, ierr)
-#ifdef UNREL
-!   For unreliable  networks.
-            call mpi_barrier(MPI_COMM_WORLD, ierr)
-!$omp barrier
-#endif
-#endif
-            detc_proj = .false.
-            yesmin = 0
-            if (molopt .ne. 0) then
-                yesmin = 1
-                if (rank .eq. 0 .and. .not. yesdft) write (6, *) ' Warning molecular orbitals&
-                & are constraint to be written in terms of contracted orbitals'
-                detc_proj = .true.
-                molopt = 1
-            end if
+     if (rank .eq. 0) then
+        !       default values
+        epsdgm = 1d-14 !  No more than 12 digits in diagonalization.
+        smearing = 1d-5
+        nbufd = -1
+        !       nmol=molecular-(nelup-neldo)
+        nmolmax = 0
+        nmolmaxw = 0
+        nmolmin = 0
+        nx = 0
+        ny = 0
+        nz = 0
+        ax = 0.d0
+        ay = 0.d0
+        az = 0.d0
+        weight_loc = -1.d0
+        orthoyes = .true.
+        gramyes = .true.
+        iflagerr = 1
+        if (npsar .gt. 0) then
+           add_onebody2det = .false.
         else
-            yesmin = 0
-            detc_proj = .false.
-        end if ! closed main if itestr.eq.-5
-
-!  Here we should interchange nmol_min with nmolmin because they have the
-!  opposite meaning in the code. In the code nmolmin is used for projection
-!, whereas nmol_min set to one the eigenvalues <= nmol_min. In input the
-!  meaning is opposite.
-        if (yesmin .eq. 1) then
-            nmolmat = ipf*nmolmax
-            nmolmatw = nmolmaxw
-            if (symmagp .or. ipf .eq. 2) then
-                nmolmatdo = nmolmat
-            else
-                nmolmatdo = nmolmax
-            end if
-        else
-            nmolmatdo = 0
-            nmolmat = 0
-            nmolmatw = 0
+           add_onebody2det = .true.
         end if
-        end subroutine read_datasmin_mol
+        epsrem_contr = epsdgel
+        shift_origin = .true.
+        shiftx = .false.
+        shifty = .false.
+        shiftz = .false.
+        read (5, nml=molecul, err=121)
+        write (6, *) ' After reading molecul '
+        if (yesavopt) then
+           if (rank .eq. 0) write (6, *) ' Warning yesavopt forced to false with mol optimiz.!!! '
+           yesavopt = .false.
+        end if
+        iflagerr = 0
+        if (molecular .eq. 0) then
+           write (6, *) ' Warning   fort.10 should have molecular orbitals,&
+                & please run again with the output fort.10  !'
+           if (nmol .eq. -1 .or. nmol .lt. neldo) then
+              iflagerr = 1
+              write (6, *) ' ERROR you should have molecular orbitals in fort.10 '
+              write (6, *) ' ERROR please use convertfort10mol or rerun with nmol>neldo '
+           end if
+        end if
+        if (contraction .eq. 0) then
+           iflagerr = 1
+           write (6, *) ' ERROR you should have contracted orbitals in fort.10 '
+           write (6, *) ' ERROR please introduce contraction (even fake) in your AGP '
+        end if
+
+121     if (iflagerr .ne. 0) then
+           write (6, *) ' ERROR reading molecul '
+           iflagerrall = iflagerr + iflagerrall
+        else
+           if (ny .eq. 0) then
+              ny = nx
+              write (6, *) ' Default value for ny=', ny
+           end if
+           if (nz .eq. 0) then
+              nz = ny
+              write (6, *) ' Default value for nz=', nz
+           end if
+           if (.not. iespbc) then
+              if (ay .eq. 0.d0) then
+                 ay = ax
+                 write (6, *) ' Default value for ay=', ay
+              end if
+              if (az .eq. 0.d0) then
+                 az = ay
+                 write (6, *) ' Default value for az=', az
+              end if
+           end if
+           if (symmagp .and. ipc .eq. 1) then
+              nmol = molecular - ndiff
+           else
+              nmol = (molecular - ndiff)/2
+           end if
+           write (6, *) ' Default value of nmol ', nmol
+           if (nmolmin .eq. 0) then
+              nmolmin = neldo
+              write (6, *) ' Default value of nmolmin ', nmolmin
+           end if
+           if (nmolmax .eq. 0) then
+              nmolmax = neldo
+              write (6, *) ' Default value of nmolmax ', nmolmax
+           end if
+
+           write (6, *) ' after  read molec '
+
+           if (weight_loc .eq. 0.d0) then
+              if (epsdgm .ne. 0.d0) then
+                 weight_loc = epsdgm**2
+              else
+                 weight_loc = 1d-8
+              end if
+              write (6, *) ' Default value for weight_loc =', weight_loc
+           end if
+
+           if (nmol .ne. 0 .and. nmolmax .eq. 0) then
+              nmolmax = nmol
+              write (6, *) ' Default value for nmolmax =', nmolmax
+           end if
+
+           if (nmolmaxw .eq. 0) then
+              nmolmaxw = nmolmax
+              write (6, *) ' Default value of nmolmaxw=', nmolmaxw
+           end if
+
+           if (nmolmax .lt. neldo) then
+              iflagerrall = iflagerrall + 1
+              write (6, *) ' Too small  nmolmax> =', neldo
+           end if
+
+           !       read(5,*) epsdgm
+           write (6, *) ' error converter  ', epsdgm
+           !       read(5,*) nx,ny,nz
+           write (6, *) ' # mesh read ', nx, ny, nz
+
+           if (nbufd .eq. -1) then
+#ifdef __SCALAPACK
+              if (nelorb .gt. 2000 .and. .not. yesdft) then ! with SCALAPACK no memory problem
+#else
+              if (nelorb .gt. 2000) then
+#endif
+                 nbufd = 100 ! there may be memory problems
+              else
+                 nbufd = 1000 ! almost maximum efficiency dgemm
+              end if
+              write (6, *) 'Default value for buffer =', nbufd
+           end if
+
+        end if
+
+     end if ! endif rank.eq.0
+     
+     !       never print the overlap in this case
+     printoverlap = .false.
+
+#ifdef PARALLEL
+     call mpi_bcast(epsdgm, 1, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
+     call mpi_bcast(smearing, 1, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
+     call mpi_bcast(epsrem_contr, 1, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
+     call mpi_bcast(weight_loc, 1, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
+     call mpi_bcast(nx, 1, MPI_INTEGER, 0, MPI_COMM_WORLD, ierr)
+     call mpi_bcast(ny, 1, MPI_INTEGER, 0, MPI_COMM_WORLD, ierr)
+     call mpi_bcast(nz, 1, MPI_INTEGER, 0, MPI_COMM_WORLD, ierr)
+     call mpi_bcast(nbufd, 1, MPI_INTEGER, 0, MPI_COMM_WORLD, ierr)
+     call mpi_bcast(orthoyes, 1, MPI_LOGICAL, 0, MPI_COMM_WORLD, ierr)
+     call mpi_bcast(gramyes, 1, MPI_LOGICAL, 0, MPI_COMM_WORLD, ierr)
+     call mpi_bcast(add_onebody2det, 1, MPI_LOGICAL, 0, MPI_COMM_WORLD, ierr)
+     call mpi_bcast(shift_origin, 1, MPI_LOGICAL, 0, MPI_COMM_WORLD, ierr)
+     call mpi_bcast(shiftx, 1, MPI_LOGICAL, 0, MPI_COMM_WORLD, ierr)
+     call mpi_bcast(shifty, 1, MPI_LOGICAL, 0, MPI_COMM_WORLD, ierr)
+     call mpi_bcast(shiftz, 1, MPI_LOGICAL, 0, MPI_COMM_WORLD, ierr)
+     call mpi_bcast(iflagerr, 1, MPI_INTEGER, 0, MPI_COMM_WORLD, ierr)
+     call mpi_bcast(nw_max, 1, MPI_INTEGER, 0, MPI_COMM_WORLD, ierr)
+#ifdef UNREL
+     !   For unreliable  networks.
+     call mpi_barrier(MPI_COMM_WORLD, ierr)
+     !$omp barrier
+#endif
+#endif
+
+     if (iessw .eq. 0 .and. iesup .eq. 0 .and. .not. yesdft .and. .not. read_molecul) then
+        call checkiflagerr(1, rank,&
+             &' ERROR you cannot use molopt>0 without optimizing AGP !!!')
+     end if
+
+     if (nx .eq. 0 .or. ny .eq. 0 .or. nz .eq. 0) then
+        write (errmsg, *) ' Mesh should be finite !!!', nx, ny, nz
+        call checkiflagerr(1, rank, errmsg)
+     end if
+
+     if (gramyes .and. .not. orthoyes) then
+        if (rank .eq. 0) write (6, *) &
+             &' Warning with Gram-Schmidt ortho, changed orthoyes= true'
+        orthoyes = .true.
+     end if
+     if (iespbc) then
+        ax = cellscale(1)/nx
+        ay = cellscale(2)/ny
+        az = cellscale(3)/nz
+        if (rank .eq. 0)                                                  &
+             &write (6, *) ' lattice mesh chosen ', ax, ay, az, cellscale(1)
+     else
+        if (rank .eq. 0) write (6, *) ' lattice mesh read ax,ay,az ', ax, ay, az
+        !       if(rank.eq.0) read(5,*) ax,ay,az
+#ifdef PARALLEL
+        call mpi_bcast(ax, 1, MPI_DOUBLE_PRECISION                        &
+             &, 0, MPI_COMM_WORLD, ierr)
+        call mpi_bcast(ay, 1, MPI_DOUBLE_PRECISION                        &
+             &, 0, MPI_COMM_WORLD, ierr)
+        call mpi_bcast(az, 1, MPI_DOUBLE_PRECISION                        &
+             &, 0, MPI_COMM_WORLD, ierr)
+#ifdef UNREL
+        !   For unreliable  networks.
+        call mpi_barrier(MPI_COMM_WORLD, ierr)
+        !$omp barrier
+#endif
+#endif
+     end if
+     if (ax .eq. 0 .or. ay .eq. 0 .or. az .eq. 0) then
+        write (errmsg, *) ' Lattice constants should be finite !!!', ax, ay, az
+        call checkiflagerr(1, rank, errmsg)
+     end if
+
+     if (rank .eq. 0) then
+        write (6, *) '# molecular orbital Det considered/projected'
+        write (6, *) nmol, nmolmin, nmolmax
+     end if
+
+#ifdef PARALLEL
+     call mpi_bcast(nmol, 1, MPI_INTEGER                               &
+          &, 0, MPI_COMM_WORLD, ierr)
+     call mpi_bcast(nmolmin, 1, MPI_INTEGER                            &
+          &, 0, MPI_COMM_WORLD, ierr)
+     call mpi_bcast(nmolmax, 1, MPI_INTEGER                            &
+          &, 0, MPI_COMM_WORLD, ierr)
+     call mpi_bcast(nmolmaxw, 1, MPI_INTEGER                            &
+          &, 0, MPI_COMM_WORLD, ierr)
+#ifdef UNREL
+     !   For unreliable  networks.
+     call mpi_barrier(MPI_COMM_WORLD, ierr)
+     !$omp barrier
+#endif
+#endif
+     detc_proj = .false.
+     yesmin = 0
+     if (molopt .ne. 0) then
+        yesmin = 1
+        if (rank .eq. 0 .and. .not. yesdft) write (6, *) ' Warning molecular orbitals&
+             & are constraint to be written in terms of contracted orbitals'
+        detc_proj = .true.
+        molopt = 1
+     end if
+  else
+     yesmin = 0
+     detc_proj = .false.
+  end if ! closed main if itestr.eq.-5
+
+  !  Here we should interchange nmol_min with nmolmin because they have the
+  !  opposite meaning in the code. In the code nmolmin is used for projection
+  !, whereas nmol_min set to one the eigenvalues <= nmol_min. In input the
+  !  meaning is opposite.
+  if (yesmin .eq. 1) then
+     nmolmat = ipf*nmolmax
+     nmolmatw = nmolmaxw
+     if (symmagp .or. ipf .eq. 2) then
+        nmolmatdo = nmolmat
+     else
+        nmolmatdo = nmolmax
+     end if
+  else
+     nmolmatdo = 0
+     nmolmat = 0
+     nmolmatw = 0
+  end if
+
+  ! write parameter values
+  call dump_parameters_molecul
+
+end subroutine read_datasmin_mol

--- a/src/m_common/allio.f90
+++ b/src/m_common/allio.f90
@@ -962,6 +962,372 @@ contains
         return
     end
 
+    subroutine dump_parameters_simulation
+      implicit none
+      if (rank.eq.0) then
+      write (6,*) '==== namelist simulation ===='
+      write (6,*) 'case_diel            = ', case_diel
+      write (6,*) 'compute_bands        = ', compute_bands
+      write (6,*) 'developer            = ', developer
+      write (6,*) 'dielectric_length    = ', dielectric_length
+      write (6,*) 'dielectric_ratio     = ', dielectric_ratio
+      write (6,*) 'disk_io              = ', disk_io
+      write (6,*) 'double_mesh          = ', double_mesh
+      write (6,*) 'freqcheck            = ', freqcheck
+      write (6,*) 'iopt                 = ', iopt
+      write (6,*) 'ip_reshuff           = ', ip_reshuff
+      write (6,*) 'iseedr               = ', iseedr
+      write (6,*) 'itestr4              = ', itestr4
+      write (6,*) 'kSq                  = ', kSq
+      write (6,*) 'kappar               = ', kappar
+      write (6,*) 'max_sparse_choice    = ', max_sparse_choice
+      write (6,*) 'max_target           = ', max_target
+      write (6,*) 'max_targetsr         = ', max_targetsr
+      write (6,*) 'maxtime              = ', maxtime
+      write (6,*) 'membig               = ', membig
+      write (6,*) 'membigcpu            = ', membigcpu
+      write (6,*) 'min_block            = ', min_block
+      write (6,*) 'nbra                 = ', nbra
+      write (6,*) 'neigh                = ', neigh
+      write (6,*) 'ngen                 = ', ngen
+      write (6,*) 'novec_loop1          = ', novec_loop1
+      write (6,*) 'nproc_diag           = ', nproc_diag
+      write (6,*) 'nscra                = ', nscra
+      write (6,*) 'nw                   = ', nw
+      write (6,*) 'yes_sparse           = ', yes_sparse
+      write (6,*) 'yes_sparse_choose    = ', yes_sparse_choose
+      write (6,*) 'yesfast              = ', yesfast
+      end if
+    end subroutine dump_parameters_simulation
+
+    subroutine dump_parameters_pseudo
+      implicit none
+      if (rank.eq.0) then
+      write (6,*) '==== namelist pseudo ===='
+      write (6,*) 'nintpsa              = ', nintpsa
+      write (6,*) 'npsamax              = ', npsamax
+      write (6,*) 'pseudorandom         = ', pseudorandom
+      end if
+    end subroutine dump_parameters_pseudo
+    
+    subroutine dump_parameters_readio
+      implicit none
+      if (rank.eq.0) then
+      write (6,*) '==== namelist readio ===='
+      write (6,*) 'flush_write          = ', flush_write
+      write (6,*) 'ifreqdump            = ', ifreqdump
+      write (6,*) 'iread                = ', iread
+      write (6,*) 'ncore                = ', ncore
+      write (6,*) 'nowrite12            = ', nowrite12
+      write (6,*) 'np                   = ', np
+      write (6,*) 'np3                  = ', np3
+      write (6,*) 'unreliable           = ', unreliable
+      write (6,*) 'wherescratch         = ', wherescratch
+      write (6,*) 'writescratch         = ', writescratch
+      end if
+    end subroutine dump_parameters_readio
+    
+    subroutine dump_parameters_vmc
+      implicit none
+      if (rank.eq.0) then
+      write (6,*) '==== namelist vmc ===='
+      write (6,*) 'alat2v               = ', alat2v
+      write (6,*) 'change_epscut        = ', change_epscut
+      write (6,*) 'change_tstep         = ', change_tstep
+      write (6,*) 'cutweight            = ', cutweight
+      write (6,*) 'epscut               = ', epscut
+      write (6,*) 'epscuttype           = ', epscuttype
+      write (6,*) 'epstlrat             = ', epstlrat
+      write (6,*) 'epsvar               = ', epsvar
+      write (6,*) 'hopfraction          = ', hopfraction
+      write (6,*) 'nbra_cyrus           = ', nbra_cyrus
+      write (6,*) 'npow                 = ', npow
+      write (6,*) 'shift                = ', shift
+      write (6,*) 'theta_reg            = ', theta_reg
+      write (6,*) 'true_wagner          = ', true_wagner
+      write (6,*) 'tstep                = ', tstep
+      write (6,*) 'typereg              = ', typereg
+      end if
+    end subroutine dump_parameters_vmc
+    
+    subroutine dump_parameters_dmclrdmc
+      implicit none
+      if (rank.eq.0) then
+      write (6,*) '==== namelist dmclrdmc ===='
+      write (6,*) 'add_diff             = ', add_diff
+      write (6,*) 'alat                 = ', alat
+      write (6,*) 'alat2                = ', alat2
+      write (6,*) 'better_dmc           = ', better_dmc
+      write (6,*) 'changelambda         = ', changelambda
+      write (6,*) 'cutreg               = ', cutreg
+      write (6,*) 'cutweight            = ', cutweight
+      write (6,*) 'enforce_detailb      = ', enforce_detailb
+      write (6,*) 'epscutdmc            = ', epscutdmc
+      write (6,*) 'epstldmc             = ', epstldmc
+      write (6,*) 'etry                 = ', etry
+      write (6,*) 'gamma                = ', gamma
+      write (6,*) 'iesrandoma           = ', iesrandoma
+      write (6,*) 'Klrdmc               = ', Klrdmc
+      write (6,*) 'l0_kousuke           = ', l0_kousuke
+      write (6,*) 'lrdmc_der            = ', lrdmc_der
+      write (6,*) 'lrdmc_nonodes        = ', lrdmc_nonodes
+      write (6,*) 'nbra_cyrus           = ', nbra_cyrus
+      write (6,*) 'noblocking           = ', noblocking
+      write (6,*) 'novar                = ', novar
+      write (6,*) 'npow                 = ', npow
+      write (6,*) 'nw_max               = ', nw_max
+      write (6,*) 'optbra               = ', optbra
+      write (6,*) 'parcutg              = ', parcutg
+      write (6,*) 'plat                 = ', plat
+      write (6,*) 'rejweight            = ', rejweight
+      write (6,*) 'safelrdmc            = ', safelrdmc
+      write (6,*) 'tbra                 = ', tbra
+      write (6,*) 'true_wagner          = ', true_wagner
+      write (6,*) 'tstepfn              = ', tstepfn
+      write (6,*) 'typereg              = ', typereg
+      write (6,*) 'weight_moroni        = ', weight_moroni
+      write (6,*) 'yes_fastbranch       = ', yes_fastbranch
+      write (6,*) 'yesalfe              = ', yesalfe
+      write (6,*) 'zmin                 = ', zmin
+      end if
+    end subroutine dump_parameters_dmclrdmc
+    
+    subroutine dump_parameters_optimization
+      implicit none
+      if (rank.eq.0) then
+      write (6,*) '==== namelist optimization ===='
+      write (6,*) 'beta_learning        = ', beta_learning
+      write (6,*) 'change_parr          = ', change_parr
+      write (6,*) 'change_tpar          = ', change_tpar
+      write (6,*) 'cut_sigma            = ', cut_sigma
+      write (6,*) 'delay_changeparr     = ', delay_changeparr
+      write (6,*) 'divide_tpar          = ', divide_tpar
+      write (6,*) 'eps_dyn5             = ', eps_dyn5
+      write (6,*) 'eps_umrigar          = ', eps_umrigar
+      write (6,*) 'epsdgel              = ', epsdgel
+      write (6,*) 'epsi                 = ', epsi
+      write (6,*) 'epstion              = ', epstion
+      write (6,*) 'fixpar               = ', fixpar
+      write (6,*) 'gauge_fixing         = ', gauge_fixing
+      write (6,*) 'iboot                = ', iboot
+      write (6,*) 'idyn                 = ', idyn
+      write (6,*) 'iesdonebodyoff       = ', iesdonebodyoff
+      write (6,*) 'iesdtwobodyoff       = ', iesdtwobodyoff
+      write (6,*) 'inc_tpar_frequency   = ', inc_tpar_frequency
+      write (6,*) 'k6gen                = ', k6gen
+      write (6,*) 'kl                   = ', kl
+      write (6,*) 'len_tpar_stable_list = ', len_tpar_stable_list
+      write (6,*) 'max_ortho            = ', max_ortho
+      write (6,*) 'maxiter_changeparr   = ', maxiter_changeparr
+      write (6,*) 'maxz                 = ', maxz
+      write (6,*) 'maxzj                = ', maxzj
+      write (6,*) 'minjonetwobody       = ', minjonetwobody
+      write (6,*) 'minz                 = ', minz
+      write (6,*) 'minzj                = ', minzj
+      write (6,*) 'molopt               = ', molopt
+      write (6,*) 'multiply_tpar        = ', multiply_tpar
+      write (6,*) 'n_sigmas_tpar        = ', n_sigmas_tpar
+      write (6,*) 'nbead                = ', nbead
+      write (6,*) 'nbinr                = ', nbinr
+      write (6,*) 'ncg                  = ', ncg
+      write (6,*) 'nfat                 = ', nfat
+      write (6,*) 'nmore_force          = ', nmore_force
+      write (6,*) 'noopt_onebody        = ', noopt_onebody
+      write (6,*) 'npbra                = ', npbra
+      write (6,*) 'nweight              = ', nweight
+      write (6,*) 'oldscaling           = ', oldscaling
+      write (6,*) 'onebodysz            = ', onebodysz
+      write (6,*) 'parcut               = ', parcut
+      write (6,*) 'parcute              = ', parcute
+      write (6,*) 'parcutmin            = ', parcutmin
+      write (6,*) 'parcutpar            = ', parcutpar
+      write (6,*) 'parr                 = ', parr
+      write (6,*) 'parr_max             = ', parr_max
+      write (6,*) 'parr_min             = ', parr_min
+      write (6,*) 'power                = ', power
+      write (6,*) 'prep                 = ', prep
+      write (6,*) 'scalermax            = ', scalermax
+      write (6,*) 'signalnoise          = ', signalnoise
+      write (6,*) 'srcomplex            = ', srcomplex
+      write (6,*) 'symiesup             = ', symiesup
+      write (6,*) 'symmetrize_agp       = ', symmetrize_agp
+      write (6,*) 'tcell                = ', tcell
+      write (6,*) 'tion                 = ', tion
+      write (6,*) 'tolcg                = ', tolcg
+      write (6,*) 'tpar                 = ', tpar
+      write (6,*) 'tpar_buffer_len      = ', tpar_buffer_len
+      write (6,*) 'tpar_max             = ', tpar_max
+      write (6,*) 'twobodyoff           = ', twobodyoff
+      write (6,*) 'use_stable_tpar      = ', use_stable_tpar
+      write (6,*) 'yes_adams            = ', yes_adams
+      write (6,*) 'yes_dgelscut         = ', yes_dgelscut
+      write (6,*) 'yescutdet            = ', yescutdet
+      write (6,*) 'yescutjas            = ', yescutjas
+      write (6,*) 'yesquantum           = ', yesquantum
+      write (6,*) 'yesread10            = ', yesread10
+      write (6,*) 'yeswrite10           = ', yeswrite10
+      write (6,*) 'yeswritebead         = ', yeswritebead
+      end if
+    end subroutine dump_parameters_optimization
+    
+    subroutine dump_parameters_parameters
+      implicit none
+      if (rank.eq.0) then
+      write (6,*) '==== namelist parameters ===='
+      write (6,*) 'add_pulay            = ', add_pulay
+      write (6,*) 'cutoff_p             = ', cutoff_p
+      write (6,*) 'decoupled_run        = ', decoupled_run
+      write (6,*) 'epsbas               = ', epsbas
+      write (6,*) 'epsder               = ', epsder
+      write (6,*) 'ext_pot              = ', ext_pot
+      write (6,*) 'fixa                 = ', fixa
+      write (6,*) 'fixb                 = ', fixb
+      write (6,*) 'fixc                 = ', fixc
+      write (6,*) 'iesd                 = ', iesd
+      write (6,*) 'ieser                = ', ieser
+      write (6,*) 'iesfree              = ', iesfree
+      write (6,*) 'iesinv               = ', iesinv
+      write (6,*) 'ieskin               = ', ieskin
+      write (6,*) 'iesm                 = ', iesm
+      write (6,*) 'iessw                = ', iessw
+      write (6,*) 'iesup                = ', iesup
+      write (6,*) 'isfix                = ', isfix
+      write (6,*) 'link_atom            = ', link_atom
+      write (6,*) 'mm_restr             = ', mm_restr
+      write (6,*) 'no_sjbra             = ', no_sjbra
+      write (6,*) 'nrep_bead            = ', nrep_bead
+      write (6,*) 'powerwarp            = ', powerwarp
+      write (6,*) 'pressfixed           = ', pressfixed
+      write (6,*) 'read_molecul         = ', read_molecul
+      write (6,*) 'real_agp             = ', real_agp
+      write (6,*) 'real_contracted      = ', real_contracted
+      write (6,*) 'scaleeloc            = ', scaleeloc
+      write (6,*) 'scalepulay           = ', scalepulay
+      write (6,*) 'typedyncell          = ', typedyncell
+      write (6,*) 'vdw                  = ', vdw
+      write (6,*) 'warp                 = ', warp
+      write (6,*) 'write_rwalk          = ', write_rwalk
+      write (6,*) 'yes_correct          = ', yes_correct
+      write (6,*) 'yes_kpoints          = ', yes_kpoints
+      write (6,*) 'yes_scemama          = ', yes_scemama
+      write (6,*) 'yes_scemama_open     = ', yes_scemama_open
+      write (6,*) 'yesavcov             = ', yesavcov
+      write (6,*) 'yesavopt             = ', yesavopt
+      write (6,*) 'yesavsr              = ', yesavsr
+      write (6,*) 'yesperiodize         = ', yesperiodize
+      write (6,*) 'yespress             = ', yespress
+      write (6,*) 'yespulay             = ', yespulay
+      write (6,*) 'yeszagp              = ', yeszagp
+      write (6,*) 'yeszj                = ', yeszj
+      end if
+    end subroutine dump_parameters_parameters
+    
+    subroutine dump_parameters_fitpar
+      implicit none
+      if (rank.eq.0) then
+      write (6,*) '==== namelist fitpar ===='
+      write (6,*) 'allfit               = ', allfit
+      write (6,*) 'initpar              = ', initpar
+      write (6,*) 'initparinv           = ', initparinv
+      write (6,*) 'initparsw            = ', initparsw
+      write (6,*) 'npar                 = ', npar
+      write (6,*) 'nparinv              = ', nparinv
+      write (6,*) 'nparsw               = ', nparsw
+      write (6,*) 'npower               = ', npower
+      write (6,*) 'npowersz             = ', npowersz
+      write (6,*) 'powermin             = ', powermin
+      write (6,*) 'powerminsz           = ', powerminsz
+      write (6,*) 'rmax                 = ', rmax
+      write (6,*) 'rmaxinv              = ', rmaxinv
+      write (6,*) 'rmaxj                = ', rmaxj
+      end if
+    end subroutine dump_parameters_fitpar
+    
+    subroutine dump_parameters_dynamic
+      implicit none
+      if (rank.eq.0) then
+      write (6,*) '==== namelist dynamic ===='
+      write (6,*) 'addrognoso           = ', addrognoso
+      write (6,*) 'cleanrognoso         = ', cleanrognoso
+      write (6,*) 'delta0               = ', delta0
+      write (6,*) 'delta0k              = ', delta0k
+      write (6,*) 'delta0q              = ', delta0q
+      write (6,*) 'eqcellab             = ', eqcellab
+      write (6,*) 'eqcellac             = ', eqcellac
+      write (6,*) 'eqcellbc             = ', eqcellbc
+      write (6,*) 'friction             = ', friction
+      write (6,*) 'iskipdyn             = ', iskipdyn
+      write (6,*) 'killcut              = ', killcut
+      write (6,*) 'maxdev_dyn           = ', maxdev_dyn
+      write (6,*) 'normcorr             = ', normcorr
+      write (6,*) 'scale_mass           = ', scale_mass
+      write (6,*) 'scalecov             = ', scalecov
+      write (6,*) 'smoothcut            = ', smoothcut
+      write (6,*) 'stepcg_recount       = ', stepcg_recount
+      write (6,*) 'temp                 = ', temp
+      write (6,*) 'write_cov            = ', write_cov
+      write (6,*) 'yesrootc             = ', yesrootc
+      write (6,*) 'yessecond            = ', yessecond
+      write (6,*) 'yesturboq            = ', yesturboq
+      end if
+    end subroutine dump_parameters_dynamic
+    
+    subroutine dump_parameters_unused
+      implicit none
+      if (rank.eq.0) then
+      write (6,*) '==== namelist unused ===='
+      write (6,*) 'beta                 = ', beta
+      write (6,*) 'rsignr               = ', rsignr
+      write (6,*) 'testderiv            = ', testderiv
+      end if
+    end subroutine dump_parameters_unused
+    
+    subroutine dump_parameters_molecul
+      implicit none
+      if (rank.eq.0) then
+      write (6,*) '==== namelist molecul ===='
+      write (6,*) 'add_onebody2det      = ', add_onebody2det
+      write (6,*) 'ax                   = ', ax
+      write (6,*) 'ay                   = ', ay
+      write (6,*) 'az                   = ', az
+      write (6,*) 'epsdgm               = ', epsdgm
+      write (6,*) 'epsrem_contr         = ', epsrem_contr
+      write (6,*) 'gramyes              = ', gramyes
+      write (6,*) 'nbufd                = ', nbufd
+      write (6,*) 'nmolmax              = ', nmolmax
+      write (6,*) 'nmolmaxw             = ', nmolmaxw
+      write (6,*) 'nmolmin              = ', nmolmin
+      write (6,*) 'nx                   = ', nx
+      write (6,*) 'ny                   = ', ny
+      write (6,*) 'nz                   = ', nz
+      write (6,*) 'orthoyes             = ', orthoyes
+      write (6,*) 'shift_origin         = ', shift_origin
+      write (6,*) 'shiftx               = ', shiftx
+      write (6,*) 'shifty               = ', shifty
+      write (6,*) 'shiftz               = ', shiftz
+      write (6,*) 'smearing             = ', smearing
+      write (6,*) 'weight_loc           = ', weight_loc
+      end if
+    end subroutine dump_parameters_molecul
+    
+    subroutine dump_parameters_link
+      implicit none
+      if (rank.eq.0) then
+      write (6,*) '==== namelist link ===='
+      write (6,*) 'calpha               = ', calpha
+      end if
+    end subroutine dump_parameters_link
+
+    ! subroutine dump_parameters_pot_ext
+    !   implicit none
+    !   if (rank.eq.0) then
+    !   write (6,*) '==== namelist pot_ext ===='
+    !   write (6,*) 'ext_pot              = ', ext_pot
+    !   write (6,*) 'link_atom            = ', link_atom
+    !   write (6,*) 'vdw                  = ', vdw
+    !   end if
+    ! end subroutine dump_parameters_pot_ext
+    
 end module allio
 
 subroutine prep_map(map_tmp, cellscale)

--- a/src/m_common/allio.f90
+++ b/src/m_common/allio.f90
@@ -971,7 +971,7 @@ contains
       write (6,*) 'developer            = ', developer
       write (6,*) 'dielectric_length    = ', dielectric_length
       write (6,*) 'dielectric_ratio     = ', dielectric_ratio
-      write (6,*) 'disk_io              = ', disk_io
+      write (6,*) 'disk_io              = ', trim(disk_io)
       write (6,*) 'double_mesh          = ', double_mesh
       write (6,*) 'freqcheck            = ', freqcheck
       write (6,*) 'iopt                 = ', iopt
@@ -1022,7 +1022,7 @@ contains
       write (6,*) 'np                   = ', np
       write (6,*) 'np3                  = ', np3
       write (6,*) 'unreliable           = ', unreliable
-      write (6,*) 'wherescratch         = ', wherescratch
+      write (6,*) 'wherescratch         = ', trim(wherescratch)
       write (6,*) 'writescratch         = ', writescratch
       end if
     end subroutine dump_parameters_readio

--- a/src/m_common/kpoints.f90
+++ b/src/m_common/kpoints.f90
@@ -664,4 +664,23 @@ contains
         return
     end subroutine init_random_seed
 
+    subroutine dump_parameters_kpoints(rank)
+      implicit none
+      integer,intent(in) :: rank
+      if (rank.eq.0) then
+      write (6,*) '==== namelist kpoints ===='
+      write (6,*) 'compute_bands        = ', compute_bands
+      write (6,*) 'double_kpgrid        = ', double_kpgrid
+      write (6,*) 'k1                   = ', k1
+      write (6,*) 'k2                   = ', k2
+      write (6,*) 'k3                   = ', k3
+      write (6,*) 'kp_type              = ', kp_type
+      write (6,*) 'nk1                  = ', nk1
+      write (6,*) 'nk2                  = ', nk2
+      write (6,*) 'nk3                  = ', nk3
+      write (6,*) 'skip_equivalence     = ', skip_equivalence
+      write (6,*) 'time_reversal,       = ', time_reversal
+      end if
+    end subroutine dump_parameters_kpoints
+
 end module kpoints_mod


### PR DESCRIPTION
## Summary

This pull request adds routines that print effective namelist and related control variables to standard output (typically unit 6), gated so only rank 0 writes in parallel runs. The intent is to make it easier to verify which parameters a given binary actually used and to improve reproducibility when sharing logs.

## What changed

### Core implementation

- `src/m_common/allio.f90`: Introduces a family of `dump_parameters_*` subroutines (e.g. simulation, pseudo, readio, VMC, DMC/LRDMC, optimization, unused, link, fitpar, dynamic, k-points, molecular, and related groups) that echo the corresponding variables with clear section headers.

### Read data

- `src/b_complex/read_datas.f90`: Adds a section-aware `dump_parameters` entry point (and related wiring) so dumps can be tied to named input sections where appropriate. This file also contains a substantial refactor alongside the new dump calls.

### Call sites

- Invokes the new dump logic from key programs after input is parsed or setup completes.

## Behavior notes

Output is intended for human-readable logs; expect verbose stdout when these paths run. If this becomes noisy for production, consider guarding dumps behind a namelist flag or compile-time option in a follow-up.
